### PR TITLE
changed cube_info call to allow list of ids

### DIFF
--- a/mstrio/api/cubes.py
+++ b/mstrio/api/cubes.py
@@ -10,7 +10,7 @@ def cube(connection, cube_id, verbose=False):
 
     Args:
         connection: MicroStrategy REST API connection object.
-        cube_id (str): Unique ID of the cube you wish to extract information from.
+        cube_id list(str): Unique IDs of the cubes you wish to extract information from.
         verbose (bool): Verbosity of request response; defaults to False.
 
     Returns:
@@ -20,6 +20,7 @@ def cube(connection, cube_id, verbose=False):
                             headers={'X-MSTR-AuthToken': connection.auth_token,
                                      'X-MSTR-ProjectID': connection.project_id},
                             cookies=connection.cookies,
+                            params={'id': cube_id},
                             verify=connection.ssl_verify)
     if verbose:
         print(response.url)


### PR DESCRIPTION
Moved id query into the body of the get request for cube_info. This allows for more cubes to be in the response from a single request. The other option is to use `{}".format(cube_id)` in the url.