### PR TITLE
[Hotfix] Fix to import existing cube

### DIFF
--- a/mstrio/cube.py
+++ b/mstrio/cube.py
@@ -83,7 +83,7 @@ class Cube:
         self._attr_elements = None
 
         # load dataset information
-        self.__info()
+        # self.__info() to be removed since it does not correspond anymore to the REST API guideline
         self.__definition()
         self.__remove_row_count()
 


### PR DESCRIPTION
Hotfix to correct the impossibility to load an existing cube. linked to the issue #46 