### PR TITLE
Use a custom logger over the root one

### DIFF
--- a/mstrio/config.py
+++ b/mstrio/config.py
@@ -47,7 +47,7 @@ logger_stream_handler = logging.StreamHandler(stream=sys.stdout)
 # warns issued by the warnings module will be redirected to the logging.warning
 logging.captureWarnings(True)
 
-logger = logging.getLogger()
+logger = logging.getLogger("mstrio")
 warnings_logger = logging.getLogger("py.warnings")
 
 logger.addHandler(logger_stream_handler)


### PR DESCRIPTION
No library should use the root logger since it changes the config completely to its user.