### PR TITLE
Add Mosaic API coverage: data models, workspaces, smart attributes, settings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+### New features
+
+- added `modeling.data_model` module with `DataModel` class and component classes
+  (`DataModelTable`, `DataModelAttribute`, `DataModelMetric`, `DataModelFactMetric`,
+  `DataModelSecurityFilter`) supporting full Mosaic data model lifecycle: create, alter,
+  save as, YAML export/restore, publish with status polling, folders, links, external
+  data models, object ACLs and translations, and listing via `list_data_models`
+- added `Workspace`, `Pipeline` and `PipelineTable` classes in `project_objects.workspace`
+  module for Mosaic data-server workspaces
+- added smart attributes support: `SmartAttribute` class with `list_smart_attributes`,
+  `list_smart_attribute_templates` and `update_smart_attributes` functions, plus
+  data-model-scoped variants on `DataModelAttribute`
+- added Mosaic settings management in `server.mosaic` module: `get_mosaic_settings`,
+  `stage_mosaic_settings`, `commit_mosaic_settings` and `upload_mosaic_keytab`
+
 ## 11.6.6.101 - 2026/06/18
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ Since version **11.3.0.1**, **mstrio-py** includes also administration modules:
 
 <!-- tox:docs:sort:start -->
 
+- **Data Model** management module for Mosaic data models (see [code_snippets][code_snippet_data_models])
+- **Workspace** and **Pipeline** management modules for Mosaic data preparation (see [code_snippets][code_snippet_workspaces])
+- **Smart Attributes** management module (see [code_snippets][code_snippet_smart_attributes])
+- **Mosaic settings** management module (see [code_snippets][code_snippet_mosaic_admin])
 - **Project** management module (see [code_snippets][code_snippet_project]) with **VLDB settings** management (see [code_snippets][code_snippet_vldb])
 - **Project languages** management module (see [code_snippets][code_snippet_project_languages])
 - **Server** management module (see [code_snippets][code_snippet_server])
@@ -202,6 +206,7 @@ When features (modules, parameters, attributes, methods etc.) are marked for dep
 [code_snippet_conn]: https://github.com/MicroStrategy/mstrio-py/blob/master/code_snippets/connect.py
 [code_snippet_contact]: https://github.com/MicroStrategy/mstrio-py/blob/master/code_snippets/contacts.py
 [code_snippet_contact_group]: https://github.com/MicroStrategy/mstrio-py/blob/master/code_snippets/contact_group_mgmt.py
+[code_snippet_data_models]: https://github.com/MicroStrategy/mstrio-py/blob/master/code_snippets/data_models.py
 [code_snippet_device]: https://github.com/MicroStrategy/mstrio-py/blob/master/code_snippets/device_mgmt.py
 [code_snippet_import]: https://github.com/MicroStrategy/mstrio-py/blob/master/code_snippets/cube_report.py
 [code_snippet_export]: https://github.com/MicroStrategy/mstrio-py/blob/master/code_snippets/create_super_cube.py
@@ -250,3 +255,6 @@ When features (modules, parameters, attributes, methods etc.) are marked for dep
 [code_snippet_scripts]: https://github.com/MicroStrategy/mstrio-py/blob/master/code_snippets/scripts.py
 [code_snippet_pa_stats]: https://github.com/MicroStrategy/mstrio-py/blob/master/code_snippets/pa_statistics_mgmt.py
 [code_snippet_hl]: https://github.com/MicroStrategy/mstrio-py/blob/master/code_snippets/history_list.py
+[code_snippet_workspaces]: https://github.com/MicroStrategy/mstrio-py/blob/master/code_snippets/workspaces.py
+[code_snippet_smart_attributes]: https://github.com/MicroStrategy/mstrio-py/blob/master/code_snippets/smart_attributes.py
+[code_snippet_mosaic_admin]: https://github.com/MicroStrategy/mstrio-py/blob/master/code_snippets/mosaic_admin.py

--- a/code_snippets/data_models.py
+++ b/code_snippets/data_models.py
@@ -1,0 +1,270 @@
+"""This is the demo script to show how to manage Mosaic data models.
+Its basic goal is to present what can be done with this module and to ease
+its usage.
+"""
+
+from mstrio.connection import get_connection
+from mstrio.modeling.data_model import (
+    DataModel,
+    DataModelAttribute,
+    DataModelMetric,
+    DataModelSecurityFilter,
+    DataModelTable,
+    DataServeMode,
+    RefreshPolicy,
+    list_data_model_attributes,
+    list_data_model_metrics,
+    list_data_model_security_filters,
+    list_data_model_tables,
+    list_data_models,
+)
+
+# Define a variable which can be later used in a script
+PROJECT_ID = $project_id  # Insert ID of project here
+
+conn = get_connection(connectionData, project_id=PROJECT_ID)
+
+# List data models with different conditions
+# Note: data models share the metadata subtype with classic super cubes,
+# so classic super cubes may appear in the results as well
+list_of_all_dms = list_data_models(connection=conn)
+print(list_of_all_dms)
+list_of_all_dms_as_dicts = list_data_models(connection=conn, to_dictionary=True)
+print(list_of_all_dms_as_dicts)
+
+# Define variables which can be later used in a script
+DM_NAME = $dm_name  # Insert name of data model here
+FOLDER_ID = $folder_id  # Insert ID of destination folder here
+
+# Create a data model. Servers enforce a minimum committable model: at
+# least one table (error 8004e46f), each table with at least one attribute
+# or metric (8004e42f), and each attribute with `displays` (8004cf06) —
+# so provide `tables` and `attributes` together. In attribute bodies,
+# logical tables created in the same call may be referenced by name.
+ID_FORM = '45C11FA478E745FEA08D781CEA190FE5'  # universal system ID form
+dm = DataModel.create(
+    connection=conn,
+    name=DM_NAME,
+    destination_folder=FOLDER_ID,
+    data_serve_mode=DataServeMode.CONNECT_LIVE,
+    description='Data model created via mstrio-py',
+    tables=[
+        {
+            'name': $table_name,  # Insert name of logical table here
+            'physicalTable': {
+                # 'warehouse_partition_table', 'pipeline' or 'freeform_sql'
+                'type': $physical_table_type,
+                # provide the fields matching the chosen type, e.g. for
+                # 'warehouse_partition_table': 'namespace', 'tableName' and
+                # 'databaseInstance': {'objectId': $datasource_id}
+                'columns': [
+                    {
+                        'columnName': $column_name,
+                        'dataType': {
+                            'type': $data_type,  # e.g. 'utf8_char'
+                            'precision': $precision,
+                            'scale': $scale,
+                        },
+                    },
+                ],
+                'information': {'name': $physical_table_name},
+            },
+        },
+    ],
+    attributes=[
+        {
+            'information': {'name': $attribute_name},
+            'forms': [
+                {
+                    'id': ID_FORM,
+                    'category': 'ID',
+                    'type': 'system',
+                    'displayFormat': 'text',
+                    'expressions': [
+                        {
+                            'expression': {
+                                'tokens': [
+                                    {
+                                        'type': 'column_reference',
+                                        'value': $column_name,
+                                    },
+                                ],
+                            },
+                            'tables': [$table_name],  # by-name reference
+                        },
+                    ],
+                    'lookupTable': $table_name,  # by-name reference
+                },
+            ],
+            'keyForm': {'id': ID_FORM},
+            'displays': {
+                'reportDisplays': [{'id': ID_FORM}],
+                'browseDisplays': [{'id': ID_FORM}],
+            },
+            'attributeLookupTable': $table_name,  # by-name reference
+        },
+    ],
+)
+
+# Define a variable which can be later used in a script
+DM_ID = $dm_id  # Insert ID of data model here
+
+# Get a data model by its id or name
+dm = DataModel(connection=conn, id=DM_ID)
+dm = DataModel(connection=conn, name=DM_NAME)
+
+# Define variables which can be later used in a script
+DM_NAME_ALTERED = $dm_name_altered
+DM_DESCRIPTION_ALTERED = $dm_description_altered
+
+# Alter a data model
+dm.alter(
+    name=DM_NAME_ALTERED,
+    description=DM_DESCRIPTION_ALTERED,
+    data_serve_mode=DataServeMode.IN_MEMORY,
+)
+
+# Define variables which can be later used in a script
+TABLE_NAME = $table_name
+NAMESPACE = $namespace  # Insert warehouse namespace (schema) here
+PHYSICAL_TABLE_NAME = $physical_table_name
+DATABASE_INSTANCE_ID = $database_instance_id
+
+# Add a table to a data model based on a warehouse table
+# Note: replace warehouse-catalog sentinel dataTypes (precision -1 /
+# scale -MIN_INT) in the columns before publishing, otherwise publish
+# will silently no-op
+table = DataModelTable.create(
+    connection=conn,
+    data_model=dm,
+    name=TABLE_NAME,
+    physical_table={
+        'type': 'warehouse_partition_table',
+        'namespace': NAMESPACE,
+        'tableName': PHYSICAL_TABLE_NAME,
+        'databaseInstance': {'objectId': DATABASE_INSTANCE_ID},
+    },
+)
+
+# List tables of a data model
+tables = list_data_model_tables(connection=conn, data_model=dm)
+tables = dm.list_tables()
+print(tables)
+
+# Define variables which can be later used in a script
+ATTRIBUTE_NAME = $attribute_name
+ATTRIBUTE_FORM = $attribute_form  # Insert form definition dict here
+
+# Create an attribute in a data model
+attribute = DataModelAttribute.create(
+    connection=conn,
+    data_model=dm,
+    name=ATTRIBUTE_NAME,
+    forms=[ATTRIBUTE_FORM],
+)
+
+# List attributes of a data model
+attributes = list_data_model_attributes(connection=conn, data_model=dm)
+attributes = dm.list_attributes()
+print(attributes)
+
+# Manage attribute relationships
+# Note: the update is a PUT replacing the ENTIRE relationship list -
+# read, modify and send the full list back
+relationships = attribute.list_relationships()
+attribute.update_relationships(relationships)
+
+# List elements of an attribute (runtime endpoint)
+elements = attribute.list_elements(limit=10)
+print(elements)
+
+# Smart attributes of a data model attribute
+smart_attributes = attribute.list_smart_attributes()
+smart_attribute_templates = attribute.list_smart_attribute_templates()
+# Passing None regenerates the service-managed smart attributes
+attribute.update_smart_attributes()
+
+# Define variables which can be later used in a script
+METRIC_NAME = $metric_name
+METRIC_EXPRESSION = $metric_expression  # Insert expression dict here
+
+# Create a metric in a data model
+metric = DataModelMetric.create(
+    connection=conn,
+    data_model=dm,
+    name=METRIC_NAME,
+    expression=METRIC_EXPRESSION,
+)
+
+# List metrics and fact metrics of a data model
+metrics = list_data_model_metrics(connection=conn, data_model=dm)
+fact_metrics = dm.list_fact_metrics()
+print(metrics)
+print(fact_metrics)
+
+# Publish a data model and wait for completion
+# Note: publish is a 3-step flow (instance -> publish -> status poll);
+# success is reported only when every table reaches the 'loaded' status
+status = dm.publish(refresh_policy=RefreshPolicy.REPLACE)
+print(status)
+
+# Publish without waiting and poll manually
+instance_id = dm.publish(await_completion=False)
+status = dm.get_publish_status(instance_id)
+print(status)
+
+# Define variables which can be later used in a script
+SF_NAME = $sf_name
+SF_QUALIFICATION = $sf_qualification  # Insert qualification tree dict here
+USER_ID = $user_id
+
+# Create a security filter in a data model and assign members
+security_filter = DataModelSecurityFilter.create(
+    connection=conn,
+    data_model=dm,
+    name=SF_NAME,
+    qualification=SF_QUALIFICATION,
+)
+security_filters = list_data_model_security_filters(connection=conn, data_model=dm)
+security_filter.add_members([USER_ID])
+members = security_filter.list_members()
+print(members)
+security_filter.remove_members([USER_ID])
+
+# Manage folders inside a data model
+folder = dm.create_folder(name='Folder created via mstrio-py')
+folders = dm.list_folders()
+dm.delete_folder(folder_id=folder.id)
+
+# Manage object ACLs and translations inside a data model
+# Note: the ACL update is a wholesale replacement; 255 is the magic
+# "Full Control" rights mask
+acl = dm.get_object_acl(object_id=table.id, sub_type='logical_table')
+dm.update_object_acl(
+    object_id=table.id,
+    sub_type='logical_table',
+    acl={
+        USER_ID: {
+            'granted': 255,
+            'denied': 0,
+            'subType': 'user',
+            'inheritable': True,
+        }
+    },
+)
+
+# Export a data model to YAML and restore it
+yaml_definition = dm.to_yaml()
+dm.to_yaml(path='data_model.yaml')
+dm.restore_from_yaml('data_model.yaml')
+
+# Save a data model under a new name
+dm_copy = dm.save_as(name='Copy of ' + DM_NAME, destination_folder=FOLDER_ID)
+
+# Delete components and the data model itself without prompt
+metric.delete(force=True)
+attribute.delete(force=True)
+security_filter.delete(force=True)
+table.delete(force=True)
+dm_copy.delete(force=True)
+dm.delete(force=True)

--- a/code_snippets/mosaic_admin.py
+++ b/code_snippets/mosaic_admin.py
@@ -1,0 +1,74 @@
+"""This is the demo script to show how to manage Mosaic SSO settings.
+Its basic goal is to present what can be done with this module and to ease
+its usage.
+"""
+
+from mstrio.connection import get_connection
+from mstrio.server.mosaic import (
+    MosaicSsoSettings,
+    commit_mosaic_settings,
+    get_mosaic_settings,
+    stage_mosaic_settings,
+    upload_mosaic_keytab,
+)
+
+# Define a variable which can be later used in a script
+PROJECT_ID = $project_id  # Insert name of project here
+
+conn = get_connection(connectionData, project_id=PROJECT_ID)
+
+# Get the current Mosaic SSO settings
+# The `status` field tells where the settings come from:
+# 'IN_PROGRESS' - draft settings from the sidecar file
+# 'COMMITTED' - settings from the production config files
+settings = get_mosaic_settings(connection=conn)
+print(settings)
+
+# Define variables which can be later used in a script
+KEYTAB_FILE_PATH = $keytab_file_path  # Insert path to the keytab file here
+KEYTAB_FILE_NAME = $keytab_file_name  # e.g. 'mci-jpd9h-dev-http.keytab'
+
+# Upload a Mosaic keytab file to the local shared folder so other services
+# can access it. The file can be provided as a path (str or Path) - then
+# the file name defaults to the base name of the path - or as bytes with
+# an explicit file name.
+upload_mosaic_keytab(connection=conn, file=KEYTAB_FILE_PATH)
+upload_mosaic_keytab(
+    connection=conn,
+    file=open(KEYTAB_FILE_PATH, 'rb').read(),
+    file_name=KEYTAB_FILE_NAME,
+)
+
+# Define variables which can be later used in a script
+KRB5_REALM = $krb5_realm  # uppercase FQDN, e.g. 'CORP.MICROSTRATEGY.COM'
+MOSAIC_HOST = $mosaic_host  # e.g. 'demo.microstrategy.com'
+UPN_DOMAIN = $upn_domain  # first entry is used as email suffix
+
+# Build the Mosaic SSO settings
+# The read-only `status` field is stripped automatically before sending
+new_settings = MosaicSsoSettings(
+    krb5_realm=KRB5_REALM,
+    mosaic_host=MOSAIC_HOST,
+    keytab_file_name=KEYTAB_FILE_NAME,
+    upn_domains=[UPN_DOMAIN],
+)
+
+# Save draft Mosaic settings to a sidecar file without modifying
+# production config files
+stage_mosaic_settings(connection=conn, settings=new_settings)
+
+# Commit Mosaic settings to production config files
+# The server will update config.properties, krb5.conf and user-mapping.json
+# under universal semantic service and enable JWT authentication mode
+commit_mosaic_settings(connection=conn, settings=new_settings)
+
+# Settings can also be provided as a plain dictionary (camelCase keys)
+commit_mosaic_settings(
+    connection=conn,
+    settings={
+        'krb5Realm': KRB5_REALM,
+        'mosaicHost': MOSAIC_HOST,
+        'keytabFileName': KEYTAB_FILE_NAME,
+        'upnDomains': [UPN_DOMAIN],
+    },
+)

--- a/code_snippets/smart_attributes.py
+++ b/code_snippets/smart_attributes.py
@@ -1,0 +1,68 @@
+"""This is the demo script to show how to manage smart attributes.
+Its basic goal is to present what can be done with this module and to ease
+its usage.
+"""
+
+from mstrio.connection import get_connection
+from mstrio.modeling.schema.attribute.attribute import Attribute
+from mstrio.modeling.schema.attribute.smart_attribute import (
+    SmartAttribute,
+    list_smart_attributes,
+    list_smart_attribute_templates,
+    update_smart_attributes,
+)
+
+# Define a variable which can be later used in a script
+PROJECT_ID = $project_id  # Insert ID of project here
+
+conn = get_connection(connectionData, project_id=PROJECT_ID)
+
+# Define variables which can be later used in a script
+ATTRIBUTE_ID = $attribute_id  # Insert ID of the base attribute here
+
+# List smart attributes derived from a base attribute
+# The base attribute can be provided as an `Attribute` object or an ID
+smart_attrs = list_smart_attributes(connection=conn, attribute=ATTRIBUTE_ID)
+print(smart_attrs)
+smart_attrs_as_dicts = list_smart_attributes(
+    connection=conn, attribute=ATTRIBUTE_ID, to_dictionary=True
+)
+print(smart_attrs_as_dicts)
+
+# The same can be done with an `Attribute` object
+attribute = Attribute(connection=conn, id=ATTRIBUTE_ID)
+smart_attrs = list_smart_attributes(connection=conn, attribute=attribute)
+
+# List smart attribute templates that can be created for the base attribute
+templates = list_smart_attribute_templates(connection=conn, attribute=ATTRIBUTE_ID)
+print(templates)
+
+# Reconcile smart attributes for the base attribute
+# When no smart attributes are provided, the service regenerates
+# the service-managed set based on the attribute's key form
+regenerated = update_smart_attributes(connection=conn, attribute=ATTRIBUTE_ID)
+print(regenerated)
+
+# Define variables which can be later used in a script
+SMART_ATTRIBUTE_ID = $smart_attribute_id
+SMART_ATTRIBUTE_NAME = $smart_attribute_name
+
+# When smart attributes are provided, applicable entries are merged into
+# the service-managed set so fields such as `object_id` and `name` are
+# respected. Omitted existing applicable entries are kept as-is; omitted
+# missing applicable entries are auto-created, and existing non-applicable
+# smart attributes may be removed.
+reconciled = update_smart_attributes(
+    connection=conn,
+    attribute=ATTRIBUTE_ID,
+    smart_attributes=[
+        SmartAttribute(object_id=SMART_ATTRIBUTE_ID, name=SMART_ATTRIBUTE_NAME),
+    ],
+)
+print(reconciled)
+
+# Smart attributes scoped to a Mosaic data model are available through
+# `DataModelAttribute.list_smart_attributes`,
+# `DataModelAttribute.list_smart_attribute_templates` and
+# `DataModelAttribute.update_smart_attributes`
+# (see code_snippets/data_models.py)

--- a/code_snippets/workspaces.py
+++ b/code_snippets/workspaces.py
@@ -1,0 +1,117 @@
+"""This is the demo script to show how to manage Mosaic data-server
+workspaces, pipelines and pipeline tables. Its basic goal is to present
+what can be done with this module and to ease its usage.
+
+Note: there is no collection-GET endpoint for workspaces, pipelines or
+tables, so listing them is not supported. Obtain workspace and pipeline
+IDs from Studio or from data-model pipeline table definitions.
+"""
+
+from mstrio.connection import get_connection
+from mstrio.project_objects.workspace import Pipeline, PipelineTable, Workspace
+
+# Define a variable which can be later used in a script
+PROJECT_ID = $project_id  # Insert ID of project here
+
+conn = get_connection(connectionData, project_id=PROJECT_ID)
+
+# Create a workspace
+# Available dataset serve modes: 'in_memory', 'connect_live', 'off_memory'
+ws = Workspace.create(
+    connection=conn,
+    dataset_serve_mode='connect_live',
+    sampling={'type': 'first', 'rowCount': 1000},
+    project_id=PROJECT_ID,
+)
+
+# Define a variable which can be later used in a script
+WORKSPACE_ID = $workspace_id  # Insert ID of workspace here
+
+# Get a workspace by its ID
+ws = Workspace(connection=conn, id=WORKSPACE_ID)
+
+# Alter a workspace
+ws.alter(dataset_serve_mode='in_memory')
+ws.alter(sampling={'type': 'random', 'rowCount': 500})
+
+# List pipelines of a workspace (built from the workspace's definition)
+pipelines = ws.pipelines
+print(pipelines)
+
+# Create an empty pipeline in a workspace
+pipeline = ws.create_pipeline()
+
+# Define variables which can be later used in a script
+PIPELINE_NAME = $pipeline_name  # Insert name of pipeline here
+PIPELINE_ROOT_TABLE = $pipeline_root_table  # Insert root table definition here
+
+# Create a pipeline with a definition
+# `name` and `root_table` are required by the server when creating
+# a pipeline with a definition
+pipeline = ws.create_pipeline(
+    name=PIPELINE_NAME,
+    root_table=PIPELINE_ROOT_TABLE,
+)
+
+# Define a variable which can be later used in a script
+PIPELINE_ID = $pipeline_id  # Insert ID of pipeline here
+
+# Get a pipeline by its ID
+pipeline = ws.get_pipeline(pipeline_id=PIPELINE_ID)
+pipeline = Pipeline(
+    connection=conn, workspace_id=WORKSPACE_ID, id=PIPELINE_ID
+)
+
+# Define a variable which can be later used in a script
+PIPELINE_NAME_ALTERED = $pipeline_name_altered
+
+# Alter a pipeline
+pipeline.alter(name=PIPELINE_NAME_ALTERED)
+
+# Refresh a pipeline to update its data and structure
+pipeline.refresh()
+
+# Create an empty table in a pipeline
+table = pipeline.create_table()
+
+# Define a variable which can be later used in a script
+SOURCE_TABLE_BODY = $source_table_body  # Insert source table definition here
+
+# Create a table with a definition
+# The body is either a source table (`{'type': 'source', ...}` with
+# 'columns', 'importSource', 'filter', 'sampling') or a wrangle table
+# (`{'type': 'wrangle', ...}` with 'operations', 'columns', 'children')
+table = pipeline.create_table(body=SOURCE_TABLE_BODY)
+
+# Define a variable which can be later used in a script
+TABLE_ID = $table_id  # Insert ID of table here
+
+# Get a table by its ID, optionally with preview or raw data
+table = pipeline.get_table(table_id=TABLE_ID)
+table = pipeline.get_table(
+    table_id=TABLE_ID, show_preview_data=True, show_raw_data=True
+)
+table = PipelineTable(
+    connection=conn,
+    workspace_id=WORKSPACE_ID,
+    pipeline_id=PIPELINE_ID,
+    id=TABLE_ID,
+)
+
+# Fetch the latest table definition, optionally with preview data
+table.fetch(show_preview_data=True)
+
+# Define a variable which can be later used in a script
+TABLE_BODY_ALTERED = $table_body_altered  # Insert updated table definition
+
+# Alter a table
+table.alter(body=TABLE_BODY_ALTERED)
+
+# Delete a table without prompt
+table.delete(force=True)
+
+# Delete a pipeline without prompt
+pipeline.delete(force=True)
+
+# Delete a workspace without prompt
+ws.delete(force=True)

--- a/mstrio/api/data_models.py
+++ b/mstrio/api/data_models.py
@@ -1,0 +1,2862 @@
+"""REST API wrappers for Mosaic data models.
+
+Note on path asymmetry: data model endpoints live under two different
+path families. Modeling (definition) endpoints are scoped under
+'/api/model/dataModels/...' and are changeset-based, while runtime
+endpoints (instances, publish, publish status, attribute elements,
+security filter members) are scoped under '/api/dataModels/...' and
+never use changesets. A 404 on one path shape usually means the other
+shape was intended. Object ACLs and translations are the exception:
+they exist only under '/api/model/...'.
+
+Note on identity tokens: some production tenant families additionally
+expect an 'X-MSTR-IdentityToken' header on Mosaic modeling writes. The
+OpenAPI contract does not require it and `Connection` does not send it.
+If writes fail with authorization errors on such tenants,
+`connection.get_identity_token()` exists as an escape hatch; it is not
+sent by default.
+"""
+
+from mstrio.connection import Connection
+from mstrio.utils.api_helpers import changeset_manager, unpack_information
+from mstrio.utils.error_handlers import ErrorHandler
+from mstrio.utils.helper import response_handler
+
+# --------------------------------------------------------------------------
+# Runtime block ('/api/dataModels/...', no changesets)
+# --------------------------------------------------------------------------
+
+
+@ErrorHandler(err_msg="Error creating an instance of data model with ID: {id}")
+def create_data_model_instance(
+    connection: Connection,
+    id: str,
+    project_id: str | None = None,
+    show_invalid_cache_table_ids: bool = False,
+):
+    """Create a runtime instance of a data model.
+
+    The response has no body (204). The ID of the new instance is
+    returned ONLY in the 'X-MSTR-DataModelInstanceId' response header —
+    never call `.json()` on the response.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        project_id: ID of a project; if omitted, the project selected
+            on the connection is used
+        show_invalid_cache_table_ids: Specifies whether to return IDs of
+            tables with invalid caches
+
+    Return:
+        HTTP response object. Expected status: 204
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.post(
+        endpoint=f'/api/dataModels/{id}/instances',
+        headers={'X-MSTR-ProjectID': project_id},
+        params={'showInvalidCacheTableIds': show_invalid_cache_table_ids},
+    )
+
+
+@ErrorHandler(err_msg="Error deleting an instance of data model with ID: {id}")
+def delete_data_model_instance(
+    connection: Connection,
+    id: str,
+    instance_id: str,
+    project_id: str | None = None,
+):
+    """Delete a runtime instance of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        instance_id: ID of a data model instance
+        project_id: ID of a project; if omitted, the project selected
+            on the connection is used
+
+    Return:
+        HTTP response object. Expected status: 204
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.delete(
+        endpoint=f'/api/dataModels/{id}/instances/{instance_id}',
+        headers={'X-MSTR-ProjectID': project_id},
+    )
+
+
+@ErrorHandler(
+    err_msg="Error getting elements of attribute with ID: {attribute_id} "
+    "of data model with ID: {id}"
+)
+def get_data_model_attribute_elements(
+    connection: Connection,
+    id: str,
+    attribute_id: str,
+    project_id: str | None = None,
+    offset: int | None = None,
+    limit: int | None = None,
+    search_pattern: str | None = None,
+    element_id_format: str | None = None,
+    fields: str | None = None,
+):
+    """Get elements of an attribute of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        attribute_id: ID of an attribute of the data model
+        project_id: ID of a project; if omitted, the project selected
+            on the connection is used
+        offset: Starting point within the collection of returned results.
+            Used to control paging behavior.
+        limit: Maximum number of items returned for a single request.
+            Used to control paging behavior.
+        search_pattern: Text that the returned elements must contain
+        element_id_format: Format of the element IDs in the response.
+            Available value: 'TERSE_LONG'
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.get(
+        endpoint=f'/api/dataModels/{id}/attributes/{attribute_id}/elements',
+        headers={'X-MSTR-ProjectID': project_id},
+        params={
+            'offset': offset,
+            'limit': limit,
+            'searchPattern': search_pattern,
+            'elementIdFormat': element_id_format,
+            'fields': fields,
+        },
+    )
+
+
+@ErrorHandler(
+    err_msg="Error listing active security filters of data model with ID: {id}"
+)
+def list_active_security_filters(
+    connection: Connection,
+    id: str,
+    project_id: str | None = None,
+    offset: int | None = None,
+    limit: int | None = None,
+    fields: str | None = None,
+):
+    """List active (runtime) security filters of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        project_id: ID of a project; if omitted, the project selected
+            on the connection is used
+        offset: Starting point within the collection of returned results.
+            Used to control paging behavior.
+        limit: Maximum number of items returned for a single request.
+            Used to control paging behavior.
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.get(
+        endpoint=f'/api/dataModels/{id}/securityFilters',
+        headers={'X-MSTR-ProjectID': project_id},
+        params={'offset': offset, 'limit': limit, 'fields': fields},
+    )
+
+
+@ErrorHandler(
+    err_msg="Error getting members of security filter with ID: "
+    "{security_filter_id} of data model with ID: {id}"
+)
+def get_security_filter_members(
+    connection: Connection,
+    id: str,
+    security_filter_id: str,
+    project_id: str | None = None,
+    offset: int | None = None,
+    limit: int | None = None,
+    fields: str | None = None,
+):
+    """Get users and user groups a data model security filter is applied to.
+
+    The response contains split 'users' and 'userGroups' arrays with
+    authoritative 'totalUsers' / 'totalUserGroups' counters.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        security_filter_id: ID of a security filter of the data model
+        project_id: ID of a project; if omitted, the project selected
+            on the connection is used
+        offset: Starting point within the collection of returned results.
+            Used to control paging behavior.
+        limit: Maximum number of items returned for a single request.
+            Used to control paging behavior.
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.get(
+        endpoint=(f'/api/dataModels/{id}/securityFilters/{security_filter_id}/members'),
+        headers={'X-MSTR-ProjectID': project_id},
+        params={'offset': offset, 'limit': limit, 'fields': fields},
+    )
+
+
+@ErrorHandler(
+    err_msg="Error updating members of security filter with ID: "
+    "{security_filter_id} of data model with ID: {id}"
+)
+def update_security_filter_members(
+    connection: Connection,
+    id: str,
+    security_filter_id: str,
+    body: dict,
+    project_id: str | None = None,
+):
+    """Update members of a data model security filter.
+
+    The body must be of the form:
+    `{'operationList': [{'op': <verb>, 'path': '/Members',
+    'value': [<user or user group IDs>]}]}` where `op` MUST be one of
+    the one-word camelCase verbs 'addElements', 'removeElements' or
+    'replaceElements' (a plain 'add' is rejected) and `path` MUST be
+    exactly '/Members' (leading slash, capital M). The response is
+    204 with an empty body on success.
+
+    Warning: this runtime path ('/api/dataModels/...') is the ONLY
+    working members path — the '/api/model/...' variant 404s. Member
+    assignment also requires the security filter's creation changeset
+    to be committed first.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        security_filter_id: ID of a security filter of the data model
+        body: Members update data ('operationList' shape above)
+        project_id: ID of a project; if omitted, the project selected
+            on the connection is used
+
+    Return:
+        HTTP response object. Expected status: 204
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.patch(
+        endpoint=(f'/api/dataModels/{id}/securityFilters/{security_filter_id}/members'),
+        headers={'X-MSTR-ProjectID': project_id},
+        json=body,
+    )
+
+
+@ErrorHandler(err_msg="Error getting publish status of data model with ID: {id}")
+def get_publish_status(
+    connection: Connection,
+    id: str,
+    instance_id: str,
+    project_id: str | None = None,
+    fields: str | None = None,
+):
+    """Poll the publish status of a data model instance.
+
+    The instance ID is sent in the 'X-MSTR-DataModelInstanceId' header
+    (required). Top-level 'status' semantics: 0 = all tables loaded,
+    1 = queued/running, 5 = reserved, 6 = schema compared, negative =
+    server error (e.g. -2147212544 = tenant-side QueryEngine stall —
+    do not retry-loop; fall back to 'connect_live' serve mode).
+
+    Warning (field-verified): instance IDs expire after ~2 minutes —
+    a 404 ERR004 on this endpoint means the instance is gone; mint a
+    new instance and re-publish.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        instance_id: ID of a data model instance (from the
+            'X-MSTR-DataModelInstanceId' response header of
+            `create_data_model_instance`)
+        project_id: ID of a project; if omitted, the project selected
+            on the connection is used
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.get(
+        endpoint=f'/api/dataModels/{id}/publishStatus',
+        headers={
+            'X-MSTR-DataModelInstanceId': instance_id,
+            'X-MSTR-ProjectID': project_id,
+        },
+        params={'fields': fields},
+    )
+
+
+@ErrorHandler(err_msg="Error publishing data model with ID: {id}")
+def publish_data_model(
+    connection: Connection,
+    id: str,
+    instance_id: str,
+    body: dict,
+    project_id: str | None = None,
+):
+    """Publish a data model instance.
+
+    The instance ID is sent in the 'X-MSTR-DataModelInstanceId' header
+    (required). The body is required and must list every logical table:
+    `{'tables': [{'id': <logical table ID>, 'refreshPolicy':
+    'replace' | 'add' | 'delete' | 'update' | 'upsert' | ...}]}`
+    (DataModelRefreshSetting schema). An empty body returns 400
+    "tableRefreshSettings cannot be null".
+
+    Warning (field-verified): the 204 response is fire-and-forget —
+    never report success without polling `get_publish_status` until the
+    top-level status is 0 and every table is 'loaded'.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        instance_id: ID of a data model instance (from the
+            'X-MSTR-DataModelInstanceId' response header of
+            `create_data_model_instance`)
+        body: Publish data ('tables' shape above)
+        project_id: ID of a project; if omitted, the project selected
+            on the connection is used
+
+    Return:
+        HTTP response object. Expected status: 204
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.post(
+        endpoint=f'/api/dataModels/{id}/publish',
+        headers={
+            'X-MSTR-DataModelInstanceId': instance_id,
+            'X-MSTR-ProjectID': project_id,
+        },
+        json=body,
+    )
+
+
+# --------------------------------------------------------------------------
+# Modeling block ('/api/model/dataModels/...', changeset-scoped)
+# --------------------------------------------------------------------------
+
+
+@unpack_information
+@ErrorHandler(err_msg="Error creating a data model")
+def create_data_model(
+    connection: Connection,
+    body: dict,
+    changeset_id: str | None = None,
+):
+    """Create a new data model in the changeset, based on the definition
+    provided in the request body.
+
+    Args:
+        connection: Strategy One REST API connection object
+        body: Data model creation data
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 201
+    """
+    if changeset_id is not None:
+        return connection.post(
+            endpoint='/api/model/dataModels',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.post(
+            endpoint='/api/model/dataModels',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+
+
+@unpack_information
+@ErrorHandler(err_msg="Error getting data model with ID: {id}")
+def get_data_model(
+    connection: Connection,
+    id: str,
+    changeset_id: str | None = None,
+):
+    """Get the definition of a single data model by ID.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        changeset_id: ID of a changeset
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=f'/api/model/dataModels/{id}',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+    )
+
+
+@unpack_information
+@ErrorHandler(err_msg="Error updating data model with ID: {id}")
+def update_data_model(
+    connection: Connection,
+    id: str,
+    body: dict,
+    changeset_id: str | None = None,
+):
+    """Update a specific data model in the changeset, based on the
+    definition provided in the request body.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        body: Data model update data
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if changeset_id is not None:
+        return connection.patch(
+            endpoint=f'/api/model/dataModels/{id}',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.patch(
+            endpoint=f'/api/model/dataModels/{id}',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+
+
+@ErrorHandler(err_msg="Error saving data model with ID: {id} as a new object")
+def save_data_model_as(
+    connection: Connection,
+    id: str,
+    body: dict,
+    changeset_id: str | None = None,
+):
+    """Save a data model as a new object.
+
+    The body is of the form `{'name': <name>,
+    'destinationFolderId': <folder ID, optional>}`. The response body
+    is the plain object ID string of the new data model (no
+    'information' wrapper).
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        body: Save-as data ('name', optional 'destinationFolderId')
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if changeset_id is not None:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/saveAs',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/saveAs',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+
+
+# Folders
+
+
+@ErrorHandler(err_msg="Error listing folders of data model with ID: {id}")
+def list_data_model_folders(
+    connection: Connection,
+    id: str,
+    changeset_id: str | None = None,
+    offset: int | None = None,
+    limit: int | None = None,
+):
+    """List folders of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        changeset_id: ID of a changeset
+        offset: Starting point within the collection of returned results.
+            Used to control paging behavior.
+        limit: Maximum number of items returned for a single request.
+            Used to control paging behavior.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=f'/api/model/dataModels/{id}/folders',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+        params={'limit': limit, 'offset': offset},
+    )
+
+
+@ErrorHandler(err_msg="Error creating a folder in data model with ID: {id}")
+def create_data_model_folder(
+    connection: Connection,
+    id: str,
+    body: dict,
+    changeset_id: str | None = None,
+):
+    """Create a new folder in a data model, based on the definition
+    provided in the request body.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        body: Folder creation data
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 201
+    """
+    if changeset_id is not None:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/folders',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/folders',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+
+
+@ErrorHandler(
+    err_msg="Error getting folder with ID: {folder_id} " "of data model with ID: {id}"
+)
+def get_data_model_folder(
+    connection: Connection,
+    id: str,
+    folder_id: str,
+    changeset_id: str | None = None,
+):
+    """Get the definition of a folder of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        folder_id: ID of a folder of the data model
+        changeset_id: ID of a changeset
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=f'/api/model/dataModels/{id}/folders/{folder_id}',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+    )
+
+
+@ErrorHandler(
+    err_msg="Error deleting folder with ID: {folder_id} " "of data model with ID: {id}"
+)
+def delete_data_model_folder(
+    connection: Connection,
+    id: str,
+    folder_id: str,
+    changeset_id: str | None = None,
+):
+    """Delete a folder of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        folder_id: ID of a folder of the data model
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 204
+    """
+    if changeset_id is not None:
+        return connection.delete(
+            endpoint=f'/api/model/dataModels/{id}/folders/{folder_id}',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+        )
+    with changeset_manager(connection) as changeset_id:
+        return connection.delete(
+            endpoint=f'/api/model/dataModels/{id}/folders/{folder_id}',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+        )
+
+
+@ErrorHandler(
+    err_msg="Error updating folder with ID: {folder_id} " "of data model with ID: {id}"
+)
+def update_data_model_folder(
+    connection: Connection,
+    id: str,
+    folder_id: str,
+    body: dict,
+    changeset_id: str | None = None,
+):
+    """Update a folder of a data model, based on the definition provided
+    in the request body.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        folder_id: ID of a folder of the data model
+        body: Folder update data
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if changeset_id is not None:
+        return connection.patch(
+            endpoint=f'/api/model/dataModels/{id}/folders/{folder_id}',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.patch(
+            endpoint=f'/api/model/dataModels/{id}/folders/{folder_id}',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+
+
+# Tables
+
+
+@ErrorHandler(err_msg="Error listing tables of data model with ID: {id}")
+def list_data_model_tables(
+    connection: Connection,
+    id: str,
+    changeset_id: str | None = None,
+    offset: int | None = None,
+    limit: int | None = None,
+    fields: str | None = None,
+    show_expression_as: list[str] | None = None,
+    show_derived_columns: bool | None = None,
+    show_derived_forms: bool | None = None,
+    show_relationship_candidates: bool | None = None,
+):
+    """List logical tables of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        changeset_id: ID of a changeset
+        offset: Starting point within the collection of returned results.
+            Used to control paging behavior.
+        limit: Maximum number of items returned for a single request.
+            Used to control paging behavior.
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+        show_derived_columns: Specifies whether to return derived columns
+        show_derived_forms: Specifies whether to return derived forms
+        show_relationship_candidates: Specifies whether to return
+            relationship candidates
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=f'/api/model/dataModels/{id}/tables',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+        params={
+            'limit': limit,
+            'offset': offset,
+            'fields': fields,
+            'showExpressionAs': show_expression_as,
+            'showDerivedColumns': show_derived_columns,
+            'showDerivedForms': show_derived_forms,
+            'showRelationshipCandidates': show_relationship_candidates,
+        },
+    )
+
+
+@unpack_information
+@ErrorHandler(err_msg="Error creating a table in data model with ID: {id}")
+def create_data_model_table(
+    connection: Connection,
+    id: str,
+    body: dict,
+    changeset_id: str | None = None,
+    fields: str | None = None,
+    show_derived_columns: bool | None = None,
+    show_derived_forms: bool | None = None,
+):
+    """Add a new logical table to a data model, based on the definition
+    provided in the request body.
+
+    Warning (field-verified): physical-table columns carrying
+    warehouse-catalog sentinel data types ('variable_length_string' with
+    precision -1, or decimal with scale -MIN_INT) make a later publish
+    silently no-op — normalize column data types before creating.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        body: Table creation data
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+        show_derived_columns: Specifies whether to return derived columns
+        show_derived_forms: Specifies whether to return derived forms
+
+    Return:
+        HTTP response object. Expected status: 201
+    """
+    if changeset_id is not None:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/tables',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'fields': fields,
+                'showDerivedColumns': show_derived_columns,
+                'showDerivedForms': show_derived_forms,
+            },
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/tables',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'fields': fields,
+                'showDerivedColumns': show_derived_columns,
+                'showDerivedForms': show_derived_forms,
+            },
+            json=body,
+        )
+
+
+@unpack_information
+@ErrorHandler(
+    err_msg="Error getting table with ID: {table_id} of data model with ID: {id}"
+)
+def get_data_model_table(
+    connection: Connection,
+    id: str,
+    table_id: str,
+    changeset_id: str | None = None,
+    fields: str | None = None,
+    show_expression_as: list[str] | None = None,
+    show_derived_columns: bool | None = None,
+    show_derived_forms: bool | None = None,
+    show_relationship_candidates: bool | None = None,
+):
+    """Get the definition of a logical table of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        table_id: ID of a table of the data model
+        changeset_id: ID of a changeset
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+        show_derived_columns: Specifies whether to return derived columns
+        show_derived_forms: Specifies whether to return derived forms
+        show_relationship_candidates: Specifies whether to return
+            relationship candidates
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=f'/api/model/dataModels/{id}/tables/{table_id}',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+        params={
+            'fields': fields,
+            'showExpressionAs': show_expression_as,
+            'showDerivedColumns': show_derived_columns,
+            'showDerivedForms': show_derived_forms,
+            'showRelationshipCandidates': show_relationship_candidates,
+        },
+    )
+
+
+@ErrorHandler(
+    err_msg="Error deleting table with ID: {table_id} " "of data model with ID: {id}"
+)
+def delete_data_model_table(
+    connection: Connection,
+    id: str,
+    table_id: str,
+    changeset_id: str | None = None,
+):
+    """Delete a logical table of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        table_id: ID of a table of the data model
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 204
+    """
+    if changeset_id is not None:
+        return connection.delete(
+            endpoint=f'/api/model/dataModels/{id}/tables/{table_id}',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+        )
+    with changeset_manager(connection) as changeset_id:
+        return connection.delete(
+            endpoint=f'/api/model/dataModels/{id}/tables/{table_id}',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+        )
+
+
+@unpack_information
+@ErrorHandler(
+    err_msg="Error updating table with ID: {table_id} " "of data model with ID: {id}"
+)
+def update_data_model_table(
+    connection: Connection,
+    id: str,
+    table_id: str,
+    body: dict,
+    changeset_id: str | None = None,
+    fields: str | None = None,
+    show_derived_columns: bool | None = None,
+    show_derived_forms: bool | None = None,
+):
+    """Update a logical table of a data model, based on the definition
+    provided in the request body.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        table_id: ID of a table of the data model
+        body: Table update data
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+        show_derived_columns: Specifies whether to return derived columns
+        show_derived_forms: Specifies whether to return derived forms
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if changeset_id is not None:
+        return connection.patch(
+            endpoint=f'/api/model/dataModels/{id}/tables/{table_id}',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'fields': fields,
+                'showDerivedColumns': show_derived_columns,
+                'showDerivedForms': show_derived_forms,
+            },
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.patch(
+            endpoint=f'/api/model/dataModels/{id}/tables/{table_id}',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'fields': fields,
+                'showDerivedColumns': show_derived_columns,
+                'showDerivedForms': show_derived_forms,
+            },
+            json=body,
+        )
+
+
+# Metrics
+
+
+@ErrorHandler(err_msg="Error listing metrics of data model with ID: {id}")
+def list_data_model_metrics(
+    connection: Connection,
+    id: str,
+    changeset_id: str | None = None,
+    offset: int | None = None,
+    limit: int | None = None,
+    show_expression_as: list[str] | None = None,
+    show_filter_tokens: bool | None = None,
+    fields: str | None = None,
+):
+    """List metrics of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        changeset_id: ID of a changeset
+        offset: Starting point within the collection of returned results.
+            Used to control paging behavior.
+        limit: Maximum number of items returned for a single request.
+            Used to control paging behavior.
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+        show_filter_tokens: Specifies whether 'qualification' is returned
+            in 'tokens' format, along with 'text' and 'tree' formats
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=f'/api/model/dataModels/{id}/metrics',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+        params={
+            'limit': limit,
+            'offset': offset,
+            'showExpressionAs': show_expression_as,
+            'showFilterTokens': show_filter_tokens,
+            'fields': fields,
+        },
+    )
+
+
+@unpack_information
+@ErrorHandler(err_msg="Error creating a metric in data model with ID: {id}")
+def create_data_model_metric(
+    connection: Connection,
+    id: str,
+    body: dict,
+    changeset_id: str | None = None,
+    show_expression_as: list[str] | None = None,
+    show_filter_tokens: bool | None = None,
+    show_advanced_properties: bool | None = None,
+    fields: str | None = None,
+):
+    """Create a new metric in a data model, based on the definition
+    provided in the request body.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        body: Metric creation data
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+        show_filter_tokens: Specifies whether 'qualification' is returned
+            in 'tokens' format, along with 'text' and 'tree' formats
+        show_advanced_properties: Specifies whether to retrieve the values
+            of the advanced properties
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+
+    Return:
+        HTTP response object. Expected status: 201
+    """
+    if changeset_id is not None:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/metrics',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showExpressionAs': show_expression_as,
+                'showFilterTokens': show_filter_tokens,
+                'showAdvancedProperties': show_advanced_properties,
+                'fields': fields,
+            },
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/metrics',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showExpressionAs': show_expression_as,
+                'showFilterTokens': show_filter_tokens,
+                'showAdvancedProperties': show_advanced_properties,
+                'fields': fields,
+            },
+            json=body,
+        )
+
+
+@unpack_information
+@ErrorHandler(
+    err_msg="Error getting metric with ID: {metric_id} " "of data model with ID: {id}"
+)
+def get_data_model_metric(
+    connection: Connection,
+    id: str,
+    metric_id: str,
+    changeset_id: str | None = None,
+    show_expression_as: list[str] | None = None,
+    show_filter_tokens: bool | None = None,
+    show_advanced_properties: bool | None = None,
+    fields: str | None = None,
+):
+    """Get the definition of a metric of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        metric_id: ID of a metric of the data model
+        changeset_id: ID of a changeset
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+        show_filter_tokens: Specifies whether 'qualification' is returned
+            in 'tokens' format, along with 'text' and 'tree' formats
+        show_advanced_properties: Specifies whether to retrieve the values
+            of the advanced properties
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=f'/api/model/dataModels/{id}/metrics/{metric_id}',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+        params={
+            'showExpressionAs': show_expression_as,
+            'showFilterTokens': show_filter_tokens,
+            'showAdvancedProperties': show_advanced_properties,
+            'fields': fields,
+        },
+    )
+
+
+@unpack_information
+@ErrorHandler(
+    err_msg="Error updating metric with ID: {metric_id} " "of data model with ID: {id}"
+)
+def update_data_model_metric(
+    connection: Connection,
+    id: str,
+    metric_id: str,
+    body: dict,
+    changeset_id: str | None = None,
+    show_expression_as: list[str] | None = None,
+    show_filter_tokens: bool | None = None,
+    show_advanced_properties: bool | None = None,
+    fields: str | None = None,
+):
+    """Update a metric of a data model, based on the definition provided
+    in the request body.
+
+    This is a PUT — a full replace of the metric's definition; perform a
+    read-modify-write to preserve fields you do not intend to change.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        metric_id: ID of a metric of the data model
+        body: Metric update data (full definition)
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+        show_filter_tokens: Specifies whether 'qualification' is returned
+            in 'tokens' format, along with 'text' and 'tree' formats
+        show_advanced_properties: Specifies whether to retrieve the values
+            of the advanced properties
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if changeset_id is not None:
+        return connection.put(
+            endpoint=f'/api/model/dataModels/{id}/metrics/{metric_id}',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showExpressionAs': show_expression_as,
+                'showFilterTokens': show_filter_tokens,
+                'showAdvancedProperties': show_advanced_properties,
+                'fields': fields,
+            },
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.put(
+            endpoint=f'/api/model/dataModels/{id}/metrics/{metric_id}',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showExpressionAs': show_expression_as,
+                'showFilterTokens': show_filter_tokens,
+                'showAdvancedProperties': show_advanced_properties,
+                'fields': fields,
+            },
+            json=body,
+        )
+
+
+@ErrorHandler(
+    err_msg="Error deleting metric with ID: {metric_id} " "of data model with ID: {id}"
+)
+def delete_data_model_metric(
+    connection: Connection,
+    id: str,
+    metric_id: str,
+    changeset_id: str | None = None,
+):
+    """Delete a metric of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        metric_id: ID of a metric of the data model
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 204
+    """
+    if changeset_id is not None:
+        return connection.delete(
+            endpoint=f'/api/model/dataModels/{id}/metrics/{metric_id}',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+        )
+    with changeset_manager(connection) as changeset_id:
+        return connection.delete(
+            endpoint=f'/api/model/dataModels/{id}/metrics/{metric_id}',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+        )
+
+
+@ErrorHandler(
+    err_msg="Error getting applicable advanced properties of metric with ID: "
+    "{metric_id} of data model with ID: {id}"
+)
+def get_metric_applicable_advanced_properties(
+    connection: Connection,
+    id: str,
+    metric_id: str,
+    changeset_id: str | None = None,
+    show_sql_preview: bool | None = None,
+):
+    """Get the applicable advanced properties of a metric of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        metric_id: ID of a metric of the data model
+        changeset_id: ID of a changeset
+        show_sql_preview: Specifies whether to return the SQL preview
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=(
+            f'/api/model/dataModels/{id}/metrics/{metric_id}'
+            '/applicableAdvancedProperties'
+        ),
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+        params={'showSqlPreview': show_sql_preview},
+    )
+
+
+@ErrorHandler(
+    err_msg="Error creating an embedded object in metric with ID: {metric_id} "
+    "of data model with ID: {id}"
+)
+def create_metric_embedded_object(
+    connection: Connection,
+    id: str,
+    metric_id: str,
+    body: dict,
+    changeset_id: str | None = None,
+    show_expression_as: list[str] | None = None,
+    show_filter_tokens: bool | None = None,
+):
+    """Create a new embedded object in a metric of a data model, based on
+    the definition provided in the request body.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        metric_id: ID of a metric of the data model
+        body: Embedded object creation data
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+        show_filter_tokens: Specifies whether 'qualification' is returned
+            in 'tokens' format, along with 'text' and 'tree' formats
+
+    Return:
+        HTTP response object. Expected status: 201
+    """
+    if changeset_id is not None:
+        return connection.post(
+            endpoint=(
+                f'/api/model/dataModels/{id}/metrics/{metric_id}/embeddedObjects'
+            ),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showExpressionAs': show_expression_as,
+                'showFilterTokens': show_filter_tokens,
+            },
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.post(
+            endpoint=(
+                f'/api/model/dataModels/{id}/metrics/{metric_id}/embeddedObjects'
+            ),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showExpressionAs': show_expression_as,
+                'showFilterTokens': show_filter_tokens,
+            },
+            json=body,
+        )
+
+
+@ErrorHandler(
+    err_msg="Error getting embedded object with ID: {embedded_object_id} "
+    "of metric with ID: {metric_id} of data model with ID: {id}"
+)
+def get_metric_embedded_object(
+    connection: Connection,
+    id: str,
+    metric_id: str,
+    embedded_object_id: str,
+    changeset_id: str | None = None,
+    show_expression_as: list[str] | None = None,
+    show_filter_tokens: bool | None = None,
+):
+    """Get the definition of an embedded object of a metric of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        metric_id: ID of a metric of the data model
+        embedded_object_id: ID of an embedded object of the metric
+        changeset_id: ID of a changeset
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+        show_filter_tokens: Specifies whether 'qualification' is returned
+            in 'tokens' format, along with 'text' and 'tree' formats
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=(
+            f'/api/model/dataModels/{id}/metrics/{metric_id}'
+            f'/embeddedObjects/{embedded_object_id}'
+        ),
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+        params={
+            'showExpressionAs': show_expression_as,
+            'showFilterTokens': show_filter_tokens,
+        },
+    )
+
+
+@ErrorHandler(
+    err_msg="Error updating embedded object with ID: {embedded_object_id} "
+    "of metric with ID: {metric_id} of data model with ID: {id}"
+)
+def update_metric_embedded_object(
+    connection: Connection,
+    id: str,
+    metric_id: str,
+    embedded_object_id: str,
+    body: dict,
+    changeset_id: str | None = None,
+    show_expression_as: list[str] | None = None,
+    show_filter_tokens: bool | None = None,
+):
+    """Update an embedded object of a metric of a data model, based on the
+    definition provided in the request body.
+
+    This is a PUT — a full replace of the embedded object's definition.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        metric_id: ID of a metric of the data model
+        embedded_object_id: ID of an embedded object of the metric
+        body: Embedded object update data (full definition)
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+        show_filter_tokens: Specifies whether 'qualification' is returned
+            in 'tokens' format, along with 'text' and 'tree' formats
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if changeset_id is not None:
+        return connection.put(
+            endpoint=(
+                f'/api/model/dataModels/{id}/metrics/{metric_id}'
+                f'/embeddedObjects/{embedded_object_id}'
+            ),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showExpressionAs': show_expression_as,
+                'showFilterTokens': show_filter_tokens,
+            },
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.put(
+            endpoint=(
+                f'/api/model/dataModels/{id}/metrics/{metric_id}'
+                f'/embeddedObjects/{embedded_object_id}'
+            ),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showExpressionAs': show_expression_as,
+                'showFilterTokens': show_filter_tokens,
+            },
+            json=body,
+        )
+
+
+# Object governance (ACLs, translations)
+
+
+@ErrorHandler(
+    err_msg="Error getting ACL of object with ID: {object_id} "
+    "of data model with ID: {id}"
+)
+def get_data_model_object_acl(
+    connection: Connection,
+    id: str,
+    object_id: str,
+    sub_type: str,
+    changeset_id: str | None = None,
+):
+    """Get the ACL of an object of a data model.
+
+    Warning (field-verified): the server returns 500 when 'subType' is
+    omitted, and with a WRONG subType it silently returns a
+    consistent-but-wrong facet — always pass the object's true subtype
+    (e.g. 'attribute', 'metric', 'fact_metric', 'logical_table',
+    'md_security_filter').
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        object_id: ID of an object of the data model
+        sub_type: Subtype of the object, e.g. 'attribute', 'metric',
+            'fact_metric', 'logical_table', 'md_security_filter'
+        changeset_id: ID of a changeset
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=f'/api/model/dataModels/{id}/objects/{object_id}/acl',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+        params={'subType': sub_type},
+    )
+
+
+@ErrorHandler(
+    err_msg="Error updating ACL of object with ID: {object_id} "
+    "of data model with ID: {id}"
+)
+def update_data_model_object_acl(
+    connection: Connection,
+    id: str,
+    object_id: str,
+    sub_type: str,
+    body: dict,
+    changeset_id: str | None = None,
+):
+    """Update the ACL of an object of a data model.
+
+    The body shape is `{'acl': {<trustee ID>: {'granted': <int mask>,
+    'denied': <int mask>, 'subType': 'user' | 'user_group',
+    'inheritable': <bool>}}}`. 255 is the server's magic "Full Control"
+    mask (do not decompose it from flag names).
+
+    Warning (field-verified): this PATCH is a wholesale replacement —
+    trustees omitted from the body are REMOVED from the ACL. With a
+    WRONG 'subType' it silently patches a consistent-but-wrong facet —
+    always pass the object's true subtype.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        object_id: ID of an object of the data model
+        sub_type: Subtype of the object, e.g. 'attribute', 'metric',
+            'fact_metric', 'logical_table', 'md_security_filter'
+        body: ACL update data ('acl' shape above)
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if changeset_id is not None:
+        return connection.patch(
+            endpoint=f'/api/model/dataModels/{id}/objects/{object_id}/acl',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={'subType': sub_type},
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.patch(
+            endpoint=f'/api/model/dataModels/{id}/objects/{object_id}/acl',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={'subType': sub_type},
+            json=body,
+        )
+
+
+@ErrorHandler(
+    err_msg="Error getting translations of object with ID: {object_id} "
+    "of data model with ID: {id}"
+)
+def get_data_model_object_translations(
+    connection: Connection,
+    id: str,
+    object_id: str,
+    sub_type: str,
+    changeset_id: str | None = None,
+):
+    """Get the translations of an object of a data model.
+
+    Warning (field-verified): the server returns 500 when 'subType' is
+    omitted, and with a WRONG subType it silently returns a
+    consistent-but-wrong facet — always pass the object's true subtype.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        object_id: ID of an object of the data model
+        sub_type: Subtype of the object, e.g. 'attribute', 'metric',
+            'fact_metric', 'logical_table', 'md_security_filter'
+        changeset_id: ID of a changeset
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=(f'/api/model/dataModels/{id}/objects/{object_id}/translations'),
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+        params={'subType': sub_type},
+    )
+
+
+@ErrorHandler(
+    err_msg="Error updating translations of object with ID: {object_id} "
+    "of data model with ID: {id}"
+)
+def update_data_model_object_translations(
+    connection: Connection,
+    id: str,
+    object_id: str,
+    sub_type: str,
+    body: dict,
+    changeset_id: str | None = None,
+):
+    """Update the translations of an object of a data model.
+
+    Warning (field-verified): with a WRONG 'subType' the server silently
+    patches a consistent-but-wrong facet — always pass the object's true
+    subtype.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        object_id: ID of an object of the data model
+        sub_type: Subtype of the object, e.g. 'attribute', 'metric',
+            'fact_metric', 'logical_table', 'md_security_filter'
+        body: Translations update data
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if changeset_id is not None:
+        return connection.patch(
+            endpoint=(f'/api/model/dataModels/{id}/objects/{object_id}/translations'),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={'subType': sub_type},
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.patch(
+            endpoint=(f'/api/model/dataModels/{id}/objects/{object_id}/translations'),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={'subType': sub_type},
+            json=body,
+        )
+
+
+# Security filters (modeling)
+
+
+@ErrorHandler(err_msg="Error listing security filters of data model with ID: {id}")
+def list_data_model_security_filters(
+    connection: Connection,
+    id: str,
+    changeset_id: str | None = None,
+    offset: int | None = None,
+    limit: int | None = None,
+):
+    """List security filters of a data model (modeling collection).
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        changeset_id: ID of a changeset
+        offset: Starting point within the collection of returned results.
+            Used to control paging behavior.
+        limit: Maximum number of items returned for a single request.
+            Used to control paging behavior.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=f'/api/model/dataModels/{id}/securityFilters',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+        params={'limit': limit, 'offset': offset},
+    )
+
+
+@unpack_information
+@ErrorHandler(err_msg="Error creating a security filter in data model with ID: {id}")
+def create_data_model_security_filter(
+    connection: Connection,
+    id: str,
+    body: dict,
+    changeset_id: str | None = None,
+    show_filter_tokens: bool | None = None,
+    show_expression_as: list[str] | None = None,
+):
+    """Create a new security filter in a data model, based on the
+    definition provided in the request body.
+
+    Note: 'information.subType' must be 'md_security_filter' (not
+    'security_filter'), and attribute form references in the
+    qualification need `subType: 'attribute_form_system'`. Member
+    assignment is performed via the runtime endpoint
+    (`update_security_filter_members`) and requires the creation
+    changeset to be committed first (this function commits its
+    changeset automatically).
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        body: Security filter creation data
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+        show_filter_tokens: Specifies whether 'qualification' is returned
+            in 'tokens' format, along with 'text' and 'tree' formats
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+
+    Return:
+        HTTP response object. Expected status: 201
+    """
+    if changeset_id is not None:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/securityFilters',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showFilterTokens': show_filter_tokens,
+                'showExpressionAs': show_expression_as,
+            },
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/securityFilters',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showFilterTokens': show_filter_tokens,
+                'showExpressionAs': show_expression_as,
+            },
+            json=body,
+        )
+
+
+@unpack_information
+@ErrorHandler(
+    err_msg="Error getting security filter with ID: {security_filter_id} "
+    "of data model with ID: {id}"
+)
+def get_data_model_security_filter(
+    connection: Connection,
+    id: str,
+    security_filter_id: str,
+    changeset_id: str | None = None,
+    show_filter_tokens: bool | None = None,
+    show_expression_as: list[str] | None = None,
+):
+    """Get the definition of a security filter of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        security_filter_id: ID of a security filter of the data model
+        changeset_id: ID of a changeset
+        show_filter_tokens: Specifies whether 'qualification' is returned
+            in 'tokens' format, along with 'text' and 'tree' formats
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=(f'/api/model/dataModels/{id}/securityFilters/{security_filter_id}'),
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+        params={
+            'showFilterTokens': show_filter_tokens,
+            'showExpressionAs': show_expression_as,
+        },
+    )
+
+
+@unpack_information
+@ErrorHandler(
+    err_msg="Error updating security filter with ID: {security_filter_id} "
+    "of data model with ID: {id}"
+)
+def update_data_model_security_filter(
+    connection: Connection,
+    id: str,
+    security_filter_id: str,
+    body: dict,
+    changeset_id: str | None = None,
+    show_filter_tokens: bool | None = None,
+    show_expression_as: list[str] | None = None,
+):
+    """Update a security filter of a data model, based on the definition
+    provided in the request body.
+
+    This is a PUT — a full replace of the security filter's definition.
+    Member assignment is performed via the runtime endpoint
+    (`update_security_filter_members`).
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        security_filter_id: ID of a security filter of the data model
+        body: Security filter update data (full definition)
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+        show_filter_tokens: Specifies whether 'qualification' is returned
+            in 'tokens' format, along with 'text' and 'tree' formats
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if changeset_id is not None:
+        return connection.put(
+            endpoint=(
+                f'/api/model/dataModels/{id}/securityFilters' f'/{security_filter_id}'
+            ),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showFilterTokens': show_filter_tokens,
+                'showExpressionAs': show_expression_as,
+            },
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.put(
+            endpoint=(
+                f'/api/model/dataModels/{id}/securityFilters' f'/{security_filter_id}'
+            ),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showFilterTokens': show_filter_tokens,
+                'showExpressionAs': show_expression_as,
+            },
+            json=body,
+        )
+
+
+@ErrorHandler(
+    err_msg="Error deleting security filter with ID: {security_filter_id} "
+    "of data model with ID: {id}"
+)
+def delete_data_model_security_filter(
+    connection: Connection,
+    id: str,
+    security_filter_id: str,
+    changeset_id: str | None = None,
+):
+    """Delete a security filter of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        security_filter_id: ID of a security filter of the data model
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 204
+    """
+    if changeset_id is not None:
+        return connection.delete(
+            endpoint=(
+                f'/api/model/dataModels/{id}/securityFilters' f'/{security_filter_id}'
+            ),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+        )
+    with changeset_manager(connection) as changeset_id:
+        return connection.delete(
+            endpoint=(
+                f'/api/model/dataModels/{id}/securityFilters' f'/{security_filter_id}'
+            ),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+        )
+
+
+# Hierarchy
+
+
+@ErrorHandler(err_msg="Error getting hierarchy of data model with ID: {id}")
+def get_data_model_hierarchy(
+    connection: Connection,
+    id: str,
+    changeset_id: str | None = None,
+):
+    """Get the hierarchy of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        changeset_id: ID of a changeset
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=f'/api/model/dataModels/{id}/hierarchy',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+    )
+
+
+# Attributes
+
+
+@ErrorHandler(err_msg="Error listing attributes of data model with ID: {id}")
+def list_data_model_attributes(
+    connection: Connection,
+    id: str,
+    changeset_id: str | None = None,
+    offset: int | None = None,
+    limit: int | None = None,
+    fields: str | None = None,
+    show_expression_as: list[str] | None = None,
+    show_derived_forms: bool | None = None,
+    show_subscription_filter_candidates_only: bool | None = None,
+):
+    """List attributes of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        changeset_id: ID of a changeset
+        offset: Starting point within the collection of returned results.
+            Used to control paging behavior.
+        limit: Maximum number of items returned for a single request.
+            Used to control paging behavior.
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+        show_derived_forms: Specifies whether to return derived forms
+        show_subscription_filter_candidates_only: Specifies whether to
+            return only attributes that are subscription filter candidates
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=f'/api/model/dataModels/{id}/attributes',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+        params={
+            'limit': limit,
+            'offset': offset,
+            'fields': fields,
+            'showExpressionAs': show_expression_as,
+            'showDerivedForms': show_derived_forms,
+            'showSubscriptionFilterCandidatesOnly': (
+                show_subscription_filter_candidates_only
+            ),
+        },
+    )
+
+
+@unpack_information
+@ErrorHandler(err_msg="Error creating an attribute in data model with ID: {id}")
+def create_data_model_attribute(
+    connection: Connection,
+    id: str,
+    body: dict,
+    changeset_id: str | None = None,
+    show_expression_as: list[str] | None = None,
+    fields: str | None = None,
+    allow_link: bool | None = None,
+    show_derived_forms: bool | None = None,
+):
+    """Create a new attribute in a data model, based on the definition
+    provided in the request body.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        body: Attribute creation data
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+        allow_link: Specifies whether linking is allowed
+        show_derived_forms: Specifies whether to return derived forms
+
+    Return:
+        HTTP response object. Expected status: 201
+    """
+    if changeset_id is not None:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/attributes',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showExpressionAs': show_expression_as,
+                'fields': fields,
+                'allowLink': allow_link,
+                'showDerivedForms': show_derived_forms,
+            },
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/attributes',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showExpressionAs': show_expression_as,
+                'fields': fields,
+                'allowLink': allow_link,
+                'showDerivedForms': show_derived_forms,
+            },
+            json=body,
+        )
+
+
+@unpack_information
+@ErrorHandler(
+    err_msg="Error getting attribute with ID: {attribute_id} "
+    "of data model with ID: {id}"
+)
+def get_data_model_attribute(
+    connection: Connection,
+    id: str,
+    attribute_id: str,
+    changeset_id: str | None = None,
+    show_expression_as: list[str] | None = None,
+    show_advanced_properties: bool | None = None,
+    fields: str | None = None,
+    show_derived_forms: bool | None = None,
+):
+    """Get the definition of an attribute of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        attribute_id: ID of an attribute of the data model
+        changeset_id: ID of a changeset
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+        show_advanced_properties: Specifies whether to retrieve the values
+            of the advanced properties
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+        show_derived_forms: Specifies whether to return derived forms
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=f'/api/model/dataModels/{id}/attributes/{attribute_id}',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+        params={
+            'showExpressionAs': show_expression_as,
+            'showAdvancedProperties': show_advanced_properties,
+            'fields': fields,
+            'showDerivedForms': show_derived_forms,
+        },
+    )
+
+
+@ErrorHandler(
+    err_msg="Error deleting attribute with ID: {attribute_id} "
+    "of data model with ID: {id}"
+)
+def delete_data_model_attribute(
+    connection: Connection,
+    id: str,
+    attribute_id: str,
+    changeset_id: str | None = None,
+):
+    """Delete an attribute of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        attribute_id: ID of an attribute of the data model
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 204
+    """
+    if changeset_id is not None:
+        return connection.delete(
+            endpoint=f'/api/model/dataModels/{id}/attributes/{attribute_id}',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+        )
+    with changeset_manager(connection) as changeset_id:
+        return connection.delete(
+            endpoint=f'/api/model/dataModels/{id}/attributes/{attribute_id}',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+        )
+
+
+@unpack_information
+@ErrorHandler(
+    err_msg="Error updating attribute with ID: {attribute_id} "
+    "of data model with ID: {id}"
+)
+def update_data_model_attribute(
+    connection: Connection,
+    id: str,
+    attribute_id: str,
+    body: dict,
+    changeset_id: str | None = None,
+    show_expression_as: list[str] | None = None,
+    fields: str | None = None,
+    allow_link: bool | None = None,
+    show_derived_forms: bool | None = None,
+):
+    """Update an attribute of a data model, based on the definition
+    provided in the request body.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        attribute_id: ID of an attribute of the data model
+        body: Attribute update data
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+        allow_link: Specifies whether linking is allowed
+        show_derived_forms: Specifies whether to return derived forms
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if changeset_id is not None:
+        return connection.patch(
+            endpoint=f'/api/model/dataModels/{id}/attributes/{attribute_id}',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showExpressionAs': show_expression_as,
+                'fields': fields,
+                'allowLink': allow_link,
+                'showDerivedForms': show_derived_forms,
+            },
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.patch(
+            endpoint=f'/api/model/dataModels/{id}/attributes/{attribute_id}',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showExpressionAs': show_expression_as,
+                'fields': fields,
+                'allowLink': allow_link,
+                'showDerivedForms': show_derived_forms,
+            },
+            json=body,
+        )
+
+
+@ErrorHandler(
+    err_msg="Error getting relationships of attribute with ID: {attribute_id} "
+    "of data model with ID: {id}"
+)
+def get_data_model_attribute_relationships(
+    connection: Connection,
+    id: str,
+    attribute_id: str,
+    changeset_id: str | None = None,
+):
+    """Get the relationships of an attribute of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        attribute_id: ID of an attribute of the data model
+        changeset_id: ID of a changeset
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=(
+            f'/api/model/dataModels/{id}/attributes/{attribute_id}' '/relationships'
+        ),
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+    )
+
+
+@ErrorHandler(
+    err_msg="Error updating relationships of attribute with ID: {attribute_id} "
+    "of data model with ID: {id}"
+)
+def update_data_model_attribute_relationships(
+    connection: Connection,
+    id: str,
+    attribute_id: str,
+    body: dict,
+    changeset_id: str | None = None,
+):
+    """Update the relationships of an attribute of a data model.
+
+    Warning (field-verified): this PUT replaces the attribute's ENTIRE
+    relationship list — any existing relationship omitted from the body
+    is DELETED. Always read the current relationships first and perform
+    a read-modify-write.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        attribute_id: ID of an attribute of the data model
+        body: Relationships update data (full list)
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if changeset_id is not None:
+        return connection.put(
+            endpoint=(
+                f'/api/model/dataModels/{id}/attributes/{attribute_id}' '/relationships'
+            ),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.put(
+            endpoint=(
+                f'/api/model/dataModels/{id}/attributes/{attribute_id}' '/relationships'
+            ),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+
+
+# Fact metrics
+
+
+@ErrorHandler(err_msg="Error listing fact metrics of data model with ID: {id}")
+def list_data_model_fact_metrics(
+    connection: Connection,
+    id: str,
+    changeset_id: str | None = None,
+    offset: int | None = None,
+    limit: int | None = None,
+    show_expression_as: list[str] | None = None,
+    fields: str | None = None,
+):
+    """List fact metrics of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        changeset_id: ID of a changeset
+        offset: Starting point within the collection of returned results.
+            Used to control paging behavior.
+        limit: Maximum number of items returned for a single request.
+            Used to control paging behavior.
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=f'/api/model/dataModels/{id}/factMetrics',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+        params={
+            'limit': limit,
+            'offset': offset,
+            'showExpressionAs': show_expression_as,
+            'fields': fields,
+        },
+    )
+
+
+@unpack_information
+@ErrorHandler(err_msg="Error creating a fact metric in data model with ID: {id}")
+def create_data_model_fact_metric(
+    connection: Connection,
+    id: str,
+    body: dict,
+    changeset_id: str | None = None,
+    show_expression_as: list[str] | None = None,
+    show_advanced_properties: bool | None = None,
+    allow_link: bool | None = None,
+    fields: str | None = None,
+):
+    """Create a new fact metric in a data model, based on the definition
+    provided in the request body.
+
+    Note: this endpoint also creates compound, conditional and
+    transformation metrics — the differentiator is which top-level body
+    keys are set.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        body: Fact metric creation data
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+        show_advanced_properties: Specifies whether to retrieve the values
+            of the advanced properties
+        allow_link: Specifies whether linking is allowed
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+
+    Return:
+        HTTP response object. Expected status: 201
+    """
+    if changeset_id is not None:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/factMetrics',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showExpressionAs': show_expression_as,
+                'showAdvancedProperties': show_advanced_properties,
+                'allowLink': allow_link,
+                'fields': fields,
+            },
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/factMetrics',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showExpressionAs': show_expression_as,
+                'showAdvancedProperties': show_advanced_properties,
+                'allowLink': allow_link,
+                'fields': fields,
+            },
+            json=body,
+        )
+
+
+@unpack_information
+@ErrorHandler(
+    err_msg="Error getting fact metric with ID: {fact_metric_id} "
+    "of data model with ID: {id}"
+)
+def get_data_model_fact_metric(
+    connection: Connection,
+    id: str,
+    fact_metric_id: str,
+    changeset_id: str | None = None,
+    show_expression_as: list[str] | None = None,
+    show_advanced_properties: bool | None = None,
+    fields: str | None = None,
+):
+    """Get the definition of a fact metric of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        fact_metric_id: ID of a fact metric of the data model
+        changeset_id: ID of a changeset
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+        show_advanced_properties: Specifies whether to retrieve the values
+            of the advanced properties
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=f'/api/model/dataModels/{id}/factMetrics/{fact_metric_id}',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+        params={
+            'showExpressionAs': show_expression_as,
+            'showAdvancedProperties': show_advanced_properties,
+            'fields': fields,
+        },
+    )
+
+
+@ErrorHandler(
+    err_msg="Error deleting fact metric with ID: {fact_metric_id} "
+    "of data model with ID: {id}"
+)
+def delete_data_model_fact_metric(
+    connection: Connection,
+    id: str,
+    fact_metric_id: str,
+    changeset_id: str | None = None,
+):
+    """Delete a fact metric of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        fact_metric_id: ID of a fact metric of the data model
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 204
+    """
+    if changeset_id is not None:
+        return connection.delete(
+            endpoint=(f'/api/model/dataModels/{id}/factMetrics/{fact_metric_id}'),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+        )
+    with changeset_manager(connection) as changeset_id:
+        return connection.delete(
+            endpoint=(f'/api/model/dataModels/{id}/factMetrics/{fact_metric_id}'),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+        )
+
+
+@unpack_information
+@ErrorHandler(
+    err_msg="Error updating fact metric with ID: {fact_metric_id} "
+    "of data model with ID: {id}"
+)
+def update_data_model_fact_metric(
+    connection: Connection,
+    id: str,
+    fact_metric_id: str,
+    body: dict,
+    changeset_id: str | None = None,
+    show_expression_as: list[str] | None = None,
+    show_advanced_properties: bool | None = None,
+    fields: str | None = None,
+):
+    """Update a fact metric of a data model, based on the definition
+    provided in the request body.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        fact_metric_id: ID of a fact metric of the data model
+        body: Fact metric update data
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+        show_expression_as: Specifies the format in which the expressions
+            are returned in response.
+            Available values: 'tokens', 'tree'
+            If omitted, the expression is returned in 'text' format.
+        show_advanced_properties: Specifies whether to retrieve the values
+            of the advanced properties
+        fields: A whitelist of top-level fields separated by commas.
+            Allow the client to selectively retrieve fields in the response.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if changeset_id is not None:
+        return connection.patch(
+            endpoint=(f'/api/model/dataModels/{id}/factMetrics/{fact_metric_id}'),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showExpressionAs': show_expression_as,
+                'showAdvancedProperties': show_advanced_properties,
+                'fields': fields,
+            },
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.patch(
+            endpoint=(f'/api/model/dataModels/{id}/factMetrics/{fact_metric_id}'),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            params={
+                'showExpressionAs': show_expression_as,
+                'showAdvancedProperties': show_advanced_properties,
+                'fields': fields,
+            },
+            json=body,
+        )
+
+
+# Links
+
+
+@ErrorHandler(err_msg="Error listing links of data model with ID: {id}")
+def list_data_model_links(
+    connection: Connection,
+    id: str,
+    changeset_id: str | None = None,
+    offset: int | None = None,
+    limit: int | None = None,
+):
+    """List links of a data model.
+
+    Quirk: unlike other modeling GETs, this endpoint REQUIRES the
+    'X-MSTR-MS-Changeset' header even on the GET. When `changeset_id`
+    is None, a temporary changeset is opened (and committed — harmless
+    for a read) around the call.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        changeset_id: ID of a changeset; if omitted, a temporary
+            changeset is created automatically
+        offset: Starting point within the collection of returned results.
+            Used to control paging behavior.
+        limit: Maximum number of items returned for a single request.
+            Used to control paging behavior.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    params = {'limit': limit, 'offset': offset}
+    if changeset_id is None:
+        with changeset_manager(connection) as changeset_id:
+            return connection.get(
+                endpoint=f'/api/model/dataModels/{id}/links',
+                headers={'X-MSTR-MS-Changeset': changeset_id},
+                params=params,
+            )
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=f'/api/model/dataModels/{id}/links',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+        params=params,
+    )
+
+
+@ErrorHandler(err_msg="Error updating links of data model with ID: {id}")
+def update_data_model_links(
+    connection: Connection,
+    id: str,
+    body: dict,
+    changeset_id: str | None = None,
+):
+    """Update the links of a data model.
+
+    Warning: this PUT replaces ALL links of the data model — any
+    existing link omitted from the body is DELETED. Perform a
+    read-modify-write.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        body: Links update data (full list)
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if changeset_id is not None:
+        return connection.put(
+            endpoint=f'/api/model/dataModels/{id}/links',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.put(
+            endpoint=f'/api/model/dataModels/{id}/links',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+
+
+@ErrorHandler(err_msg="Error creating a link in data model with ID: {id}")
+def create_data_model_link(
+    connection: Connection,
+    id: str,
+    body: dict,
+    changeset_id: str | None = None,
+):
+    """Create a new link in a data model, based on the definition provided
+    in the request body.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        body: Link creation data
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 201
+    """
+    if changeset_id is not None:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/links',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/links',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+
+
+# External data models
+
+
+@ErrorHandler(err_msg="Error listing external data models of data model with ID: {id}")
+def list_external_data_models(
+    connection: Connection,
+    id: str,
+    changeset_id: str | None = None,
+):
+    """List external data models of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        changeset_id: ID of a changeset
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=f'/api/model/dataModels/{id}/externalDataModels',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+    )
+
+
+@ErrorHandler(
+    err_msg="Error creating an external data model in data model with ID: {id}"
+)
+def create_external_data_model(
+    connection: Connection,
+    id: str,
+    body: dict,
+    changeset_id: str | None = None,
+):
+    """Add a new external data model to a data model, based on the
+    definition provided in the request body.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        body: External data model creation data
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 201
+    """
+    if changeset_id is not None:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/externalDataModels',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/externalDataModels',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+
+
+@ErrorHandler(
+    err_msg="Error deleting external data model with ID: "
+    "{external_data_model_id} of data model with ID: {id}"
+)
+def delete_external_data_model(
+    connection: Connection,
+    id: str,
+    external_data_model_id: str,
+    changeset_id: str | None = None,
+):
+    """Delete an external data model of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        external_data_model_id: ID of an external data model of the
+            data model
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 204
+    """
+    if changeset_id is not None:
+        return connection.delete(
+            endpoint=(
+                f'/api/model/dataModels/{id}/externalDataModels'
+                f'/{external_data_model_id}'
+            ),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+        )
+    with changeset_manager(connection) as changeset_id:
+        return connection.delete(
+            endpoint=(
+                f'/api/model/dataModels/{id}/externalDataModels'
+                f'/{external_data_model_id}'
+            ),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+        )
+
+
+@ErrorHandler(
+    err_msg="Error updating external data model with ID: "
+    "{external_data_model_id} of data model with ID: {id}"
+)
+def update_external_data_model(
+    connection: Connection,
+    id: str,
+    external_data_model_id: str,
+    body: dict,
+    changeset_id: str | None = None,
+):
+    """Update an external data model of a data model, based on the
+    definition provided in the request body.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        external_data_model_id: ID of an external data model of the
+            data model
+        body: External data model update data
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if changeset_id is not None:
+        return connection.patch(
+            endpoint=(
+                f'/api/model/dataModels/{id}/externalDataModels'
+                f'/{external_data_model_id}'
+            ),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.patch(
+            endpoint=(
+                f'/api/model/dataModels/{id}/externalDataModels'
+                f'/{external_data_model_id}'
+            ),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+
+
+@ErrorHandler(
+    err_msg="Error updating object with ID: {object_id} of external data "
+    "model with ID: {external_data_model_id} of data model with ID: {id}"
+)
+def update_external_data_model_object(
+    connection: Connection,
+    id: str,
+    external_data_model_id: str,
+    object_id: str,
+    body: dict,
+    changeset_id: str | None = None,
+):
+    """Update an object of an external data model of a data model, based
+    on the definition provided in the request body.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        external_data_model_id: ID of an external data model of the
+            data model
+        object_id: ID of an object of the external data model
+        body: External data model object update data
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if changeset_id is not None:
+        return connection.patch(
+            endpoint=(
+                f'/api/model/dataModels/{id}/externalDataModels'
+                f'/{external_data_model_id}/objects/{object_id}'
+            ),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.patch(
+            endpoint=(
+                f'/api/model/dataModels/{id}/externalDataModels'
+                f'/{external_data_model_id}/objects/{object_id}'
+            ),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+
+
+@ErrorHandler(
+    err_msg="Error refreshing external data models of data model with ID: {id}"
+)
+def refresh_external_data_models(
+    connection: Connection,
+    id: str,
+    changeset_id: str | None = None,
+):
+    """Refresh the external data models of a data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if changeset_id is not None:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/externalDataModels/refresh',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+        )
+    with changeset_manager(connection) as changeset_id:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/externalDataModels/refresh',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+        )
+
+
+# Export / restore
+
+
+def export_data_model(
+    connection: Connection,
+    id: str,
+    changeset_id: str | None = None,
+):
+    """Export a data model to YAML.
+
+    The 200 response body is 'application/yaml' TEXT, not JSON — use
+    `response.text` on the returned object; never call `.json()`.
+    When `changeset_id` is None, a temporary changeset is opened (and
+    committed — harmless for an export) around the call.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        changeset_id: ID of a changeset; if omitted, a temporary
+            changeset is created automatically
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if changeset_id is None:
+        with changeset_manager(connection) as new_changeset_id:
+            response = connection.post(
+                endpoint=f'/api/model/dataModels/{id}/export',
+                headers={'X-MSTR-MS-Changeset': new_changeset_id},
+            )
+    else:
+        response = connection.post(
+            endpoint=f'/api/model/dataModels/{id}/export',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+        )
+    if not response.ok:
+        response_handler(response, msg=f"Error exporting data model with ID: {id}")
+    return response
+
+
+@ErrorHandler(err_msg="Error restoring data model with ID: {id}")
+def restore_data_model(
+    connection: Connection,
+    id: str,
+    file: bytes | str,
+    file_name: str = 'data_model.yaml',
+    changeset_id: str | None = None,
+):
+    """Restore a data model from a YAML export.
+
+    The request is 'multipart/form-data' with a single part named
+    'dataModelFile' containing the binary YAML content.
+
+    Args:
+        connection: Strategy One REST API connection object
+        id: ID of a data model
+        file: YAML content of the data model (bytes or string)
+        file_name: Name of the uploaded file part
+        changeset_id: ID of an already-open changeset to run this
+            operation in; when omitted, a changeset is opened and
+            committed automatically.
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if changeset_id is not None:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/restore',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            files={'dataModelFile': (file_name, file)},
+        )
+    with changeset_manager(connection) as changeset_id:
+        return connection.post(
+            endpoint=f'/api/model/dataModels/{id}/restore',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            files={'dataModelFile': (file_name, file)},
+        )

--- a/mstrio/api/mosaic.py
+++ b/mstrio/api/mosaic.py
@@ -1,0 +1,112 @@
+from requests import Response
+
+from mstrio.connection import Connection
+from mstrio.utils.error_handlers import ErrorHandler
+
+
+@ErrorHandler(err_msg="Error uploading Mosaic keytab file.")
+def upload_mosaic_keytab(
+    connection: Connection, file: bytes, file_name: str
+) -> Response:
+    """Upload a Mosaic keytab file to the local shared folder so other
+    services can access it.
+
+    The request is sent as `multipart/form-data` with two parts: `fileName`
+    (original file name, used only for validation) and `file` (the keytab
+    binary).
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        file (bytes): keytab file binary
+        file_name (str): original file name of the keytab file (used only
+            for validation)
+
+    Return:
+        HTTP response object. Expected status: 204
+    """
+    return connection.post(
+        endpoint='/api/admin/mstrServices/mosaic/keytab',
+        data={'fileName': file_name},
+        files={'file': (file_name, file)},
+    )
+
+
+@ErrorHandler(err_msg="Error getting Mosaic settings.")
+def get_mosaic_settings(connection: Connection, fields: str | None = None) -> Response:
+    """Get Mosaic settings stored as files under universal semantic service.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        fields (str, optional): Comma separated top-level field whitelist. This
+            allows client to selectively retrieve part of the response model,
+            defaults to None
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    return connection.get(
+        endpoint='/api/admin/mstrServices/mosaic/settings',
+        params={'fields': fields},
+    )
+
+
+@ErrorHandler(err_msg="Error staging draft Mosaic settings.")
+def stage_mosaic_settings(connection: Connection, body: dict) -> Response:
+    """Save draft Mosaic settings to a sidecar file without modifying
+    production config files. This allows saving work-in-progress
+    configuration.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        body (dict): JSON-formatted body with the Mosaic settings payload:
+            {
+                "krb5Realm": str,
+                "domain": str (optional),
+                "mosaicHost": str,
+                "mosaicHostAliases": list[str] (optional),
+                "mosaicSvc": str (optional),
+                "keytabFileName": str,
+                "upnDomains": list[str]
+            }
+
+    Return:
+        HTTP response object. Expected status: 204
+    """
+    return connection.post(
+        endpoint='/api/admin/mstrServices/mosaic/settings/stage',
+        json=body,
+    )
+
+
+@ErrorHandler(err_msg="Error committing Mosaic settings.")
+def commit_mosaic_settings(connection: Connection, body: dict) -> Response:
+    """Commit Mosaic settings to production config files.
+
+    The server will update config.properties, krb5.conf and user-mapping.json
+    under universal semantic service. Requires existing baseline files. Also
+    enables JWT authentication mode.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        body (dict): JSON-formatted body with the Mosaic settings payload:
+            {
+                "krb5Realm": str,
+                "domain": str (optional),
+                "mosaicHost": str,
+                "mosaicHostAliases": list[str] (optional),
+                "mosaicSvc": str (optional),
+                "keytabFileName": str,
+                "upnDomains": list[str]
+            }
+
+    Return:
+        HTTP response object. Expected status: 204
+    """
+    return connection.post(
+        endpoint='/api/admin/mstrServices/mosaic/settings/commit',
+        json=body,
+    )

--- a/mstrio/api/smart_attributes.py
+++ b/mstrio/api/smart_attributes.py
@@ -1,0 +1,214 @@
+from mstrio.connection import Connection
+from mstrio.utils.api_helpers import changeset_manager
+from mstrio.utils.error_handlers import ErrorHandler
+
+
+@ErrorHandler(
+    err_msg="Error getting smart attributes for attribute with ID: {attribute_id}"
+)
+def list_smart_attributes(
+    connection: Connection,
+    attribute_id: str,
+    changeset_id: str | None = None,
+):
+    """Get a list of references to all smart attributes derived from
+    the base attribute.
+
+    Args:
+        connection: Strategy One REST API connection object
+        attribute_id: ID of the base attribute. The ID can be the object ID
+            used in metadata or the object ID used in the changeset,
+            but not yet committed to metadata.
+        changeset_id: ID of a changeset
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=f'/api/model/attributes/{attribute_id}/smartAttributes',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+    )
+
+
+@ErrorHandler(
+    err_msg="Error updating smart attributes for attribute with ID: {attribute_id}"
+)
+def update_smart_attributes(
+    connection: Connection,
+    attribute_id: str,
+    body: dict,
+):
+    """Reconcile the service-managed smart attributes for the attribute
+    based on its key form.
+
+    Note:
+        This PUT is a reconcile/merge, not a wholesale replacement. If
+        `smartAttributes` entries are provided in the body, applicable
+        entries are merged into the service-managed set so fields such as
+        `objectId`, `name` and `hidden` are respected. Omitted existing
+        applicable entries are kept as-is; omitted missing applicable
+        entries are auto-created, and existing non-applicable smart
+        attributes may be removed. Passing an empty or omitted list lets
+        the service regenerate the set.
+
+    Args:
+        connection: Strategy One REST API connection object
+        attribute_id: ID of the base attribute. The ID can be the object ID
+            used in metadata or the object ID used in the changeset,
+            but not yet committed to metadata.
+        body: Smart attributes reconciliation data in the form:
+            `{'smartAttributes': [<ms-SmartAttribute>, ...]}`
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.put(
+            endpoint=f'/api/model/attributes/{attribute_id}/smartAttributes',
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+
+
+@ErrorHandler(
+    err_msg="Error getting smart attribute templates for attribute "
+    "with ID: {attribute_id}"
+)
+def list_smart_attribute_templates(
+    connection: Connection,
+    attribute_id: str,
+    changeset_id: str | None = None,
+):
+    """Get a list of smart attribute templates that can be created
+    for the base attribute.
+
+    Args:
+        connection: Strategy One REST API connection object
+        attribute_id: ID of the base attribute. The ID can be the object ID
+            used in metadata or the object ID used in the changeset,
+            but not yet committed to metadata.
+        changeset_id: ID of a changeset
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=f'/api/model/attributes/{attribute_id}/smartAttributes/templates',
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+    )
+
+
+@ErrorHandler(
+    err_msg="Error getting smart attributes for attribute with ID: {attribute_id} "
+    "in data model with ID: {data_model_id}"
+)
+def list_data_model_smart_attributes(
+    connection: Connection,
+    data_model_id: str,
+    attribute_id: str,
+    changeset_id: str | None = None,
+):
+    """Get the smart attributes associated with a specified attribute
+    in the data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        data_model_id: ID of the data model
+        attribute_id: ID of the attribute. The ID can be the object ID
+            used in metadata or the object ID used in the changeset,
+            but not yet committed to metadata.
+        changeset_id: ID of a changeset
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=(
+            f'/api/model/dataModels/{data_model_id}/attributes/{attribute_id}'
+            '/smartAttributes'
+        ),
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+    )
+
+
+@ErrorHandler(
+    err_msg="Error updating smart attributes for attribute with ID: {attribute_id} "
+    "in data model with ID: {data_model_id}"
+)
+def update_data_model_smart_attributes(
+    connection: Connection,
+    data_model_id: str,
+    attribute_id: str,
+    body: dict,
+):
+    """Reconcile the service-managed smart attributes for a specified
+    data model attribute based on its key form.
+
+    Note:
+        This PUT is a reconcile/merge, not a wholesale replacement. If
+        `smartAttributes` entries are provided in the body, applicable
+        entries are merged into the service-managed set so fields such as
+        `objectId`, `name` and `hidden` are respected. Omitted existing
+        applicable entries are kept as-is; omitted missing applicable
+        entries are auto-created, and existing non-applicable smart
+        attributes may be removed. Passing an empty or omitted list lets
+        the service regenerate the set.
+
+    Args:
+        connection: Strategy One REST API connection object
+        data_model_id: ID of the data model
+        attribute_id: ID of the attribute. The ID can be the object ID
+            used in metadata or the object ID used in the changeset,
+            but not yet committed to metadata.
+        body: Smart attributes reconciliation data in the form:
+            `{'smartAttributes': [<ms-SmartAttribute>, ...]}`
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    with changeset_manager(connection, body=body) as changeset_id:
+        return connection.put(
+            endpoint=(
+                f'/api/model/dataModels/{data_model_id}/attributes/{attribute_id}'
+                '/smartAttributes'
+            ),
+            headers={'X-MSTR-MS-Changeset': changeset_id},
+            json=body,
+        )
+
+
+@ErrorHandler(
+    err_msg="Error getting smart attribute templates for attribute "
+    "with ID: {attribute_id} in data model with ID: {data_model_id}"
+)
+def list_data_model_smart_attribute_templates(
+    connection: Connection,
+    data_model_id: str,
+    attribute_id: str,
+    changeset_id: str | None = None,
+):
+    """Get the available smart attribute templates for a specified
+    attribute in the data model.
+
+    Args:
+        connection: Strategy One REST API connection object
+        data_model_id: ID of the data model
+        attribute_id: ID of the attribute. The ID can be the object ID
+            used in metadata or the object ID used in the changeset,
+            but not yet committed to metadata.
+        changeset_id: ID of a changeset
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    connection._validate_project_selected()
+    return connection.get(
+        endpoint=(
+            f'/api/model/dataModels/{data_model_id}/attributes/{attribute_id}'
+            '/smartAttributes/templates'
+        ),
+        headers={'X-MSTR-MS-Changeset': changeset_id},
+    )

--- a/mstrio/api/workspaces.py
+++ b/mstrio/api/workspaces.py
@@ -1,0 +1,434 @@
+"""REST API wrappers for Mosaic data-server workspaces, pipelines and tables.
+
+All endpoints live under `/api/dataServer/...`. The `X-MSTR-ProjectID` header
+is sent when `project_id` is provided; otherwise the project selected on the
+connection applies. There is NO collection-GET endpoint for workspaces,
+pipelines or tables - nested definitions are returned inside the workspace
+and pipeline GET payloads.
+"""
+
+from requests import Response
+
+from mstrio.connection import Connection
+from mstrio.utils.error_handlers import ErrorHandler
+
+
+@ErrorHandler(err_msg="Error creating a workspace.")
+def create_workspace(
+    connection: Connection, body: dict, project_id: str | None = None
+) -> Response:
+    """Create a new workspace on the data server.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        body (dict): JSON-formatted definition of the new workspace
+            (`ms-Workspace`), e.g. `{'datasetServeMode': 'connect_live',
+            'sampling': {'type': 'first', 'rowCount': 1000}}`
+        project_id (str, optional): ID of a project; if omitted, the project
+            selected on the connection is used
+
+    Return:
+        HTTP response object. Expected status: 201
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.post(
+        endpoint='/api/dataServer/workspaces',
+        headers={'X-MSTR-ProjectID': project_id},
+        json=body,
+    )
+
+
+@ErrorHandler(err_msg="Error getting workspace with ID: {id}.")
+def get_workspace(
+    connection: Connection, id: str, project_id: str | None = None
+) -> Response:
+    """Get the definition of a single workspace on the data server.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        id (str): ID of the workspace
+        project_id (str, optional): ID of a project; if omitted, the project
+            selected on the connection is used
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.get(
+        endpoint=f'/api/dataServer/workspaces/{id}',
+        headers={'X-MSTR-ProjectID': project_id},
+    )
+
+
+@ErrorHandler(err_msg="Error deleting workspace with ID: {id}.")
+def delete_workspace(
+    connection: Connection, id: str, project_id: str | None = None
+) -> Response:
+    """Delete a workspace on the data server.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        id (str): ID of the workspace
+        project_id (str, optional): ID of a project; if omitted, the project
+            selected on the connection is used
+
+    Return:
+        HTTP response object. Expected status: 204
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.delete(
+        endpoint=f'/api/dataServer/workspaces/{id}',
+        headers={'X-MSTR-ProjectID': project_id},
+    )
+
+
+@ErrorHandler(err_msg="Error updating workspace with ID: {id}.")
+def update_workspace(
+    connection: Connection, id: str, body: dict, project_id: str | None = None
+) -> Response:
+    """Update a workspace on the data server. Returns the workspace's
+    updated definition.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        id (str): ID of the workspace
+        body (dict): one or more top-level `ms-Workspace` fields with the new
+            definition of the workspace (the endpoint also accepts
+            `application/merge-patch+json`; plain `application/json` is sent)
+        project_id (str, optional): ID of a project; if omitted, the project
+            selected on the connection is used
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.patch(
+        endpoint=f'/api/dataServer/workspaces/{id}',
+        headers={'X-MSTR-ProjectID': project_id},
+        json=body,
+    )
+
+
+@ErrorHandler(err_msg="Error creating a pipeline in workspace with ID: {workspace_id}.")
+def create_pipeline(
+    connection: Connection,
+    workspace_id: str,
+    body: dict | None = None,
+    project_id: str | None = None,
+) -> Response:
+    """Create a new pipeline in the specified workspace.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        workspace_id (str): ID of the workspace
+        body (dict, optional): JSON-formatted definition of the new pipeline
+            (`ms-Pipeline`, required fields on create-with-definition: `name`,
+            `rootTable`); an empty object `{}` (the default) creates a new
+            empty pipeline
+        project_id (str, optional): ID of a project; if omitted, the project
+            selected on the connection is used
+
+    Return:
+        HTTP response object. Expected status: 201
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.post(
+        endpoint=f'/api/dataServer/workspaces/{workspace_id}/pipelines',
+        headers={'X-MSTR-ProjectID': project_id},
+        json=body if body is not None else {},
+    )
+
+
+@ErrorHandler(err_msg="Error getting pipeline with ID: {pipeline_id}.")
+def get_pipeline(
+    connection: Connection,
+    workspace_id: str,
+    pipeline_id: str,
+    project_id: str | None = None,
+) -> Response:
+    """Retrieve a specific pipeline by its ID.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        workspace_id (str): ID of the workspace
+        pipeline_id (str): ID of the pipeline
+        project_id (str, optional): ID of a project; if omitted, the project
+            selected on the connection is used
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.get(
+        endpoint=(f'/api/dataServer/workspaces/{workspace_id}/pipelines/{pipeline_id}'),
+        headers={'X-MSTR-ProjectID': project_id},
+    )
+
+
+@ErrorHandler(err_msg="Error deleting pipeline with ID: {pipeline_id}.")
+def delete_pipeline(
+    connection: Connection,
+    workspace_id: str,
+    pipeline_id: str,
+    project_id: str | None = None,
+) -> Response:
+    """Delete a specific pipeline.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        workspace_id (str): ID of the workspace
+        pipeline_id (str): ID of the pipeline
+        project_id (str, optional): ID of a project; if omitted, the project
+            selected on the connection is used
+
+    Return:
+        HTTP response object. Expected status: 204
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.delete(
+        endpoint=(f'/api/dataServer/workspaces/{workspace_id}/pipelines/{pipeline_id}'),
+        headers={'X-MSTR-ProjectID': project_id},
+    )
+
+
+@ErrorHandler(err_msg="Error updating pipeline with ID: {pipeline_id}.")
+def update_pipeline(
+    connection: Connection,
+    workspace_id: str,
+    pipeline_id: str,
+    body: dict,
+    project_id: str | None = None,
+) -> Response:
+    """Update an existing pipeline. Returns the pipeline's updated definition.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        workspace_id (str): ID of the workspace
+        pipeline_id (str): ID of the pipeline
+        body (dict): JSON-formatted `ms-Pipeline` definition update
+        project_id (str, optional): ID of a project; if omitted, the project
+            selected on the connection is used
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.patch(
+        endpoint=(f'/api/dataServer/workspaces/{workspace_id}/pipelines/{pipeline_id}'),
+        headers={'X-MSTR-ProjectID': project_id},
+        json=body,
+    )
+
+
+@ErrorHandler(err_msg="Error refreshing pipeline with ID: {pipeline_id}.")
+def refresh_pipeline(
+    connection: Connection,
+    workspace_id: str,
+    pipeline_id: str,
+    project_id: str | None = None,
+) -> Response:
+    """Refresh a pipeline to update its data and structure.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        workspace_id (str): ID of the workspace
+        pipeline_id (str): ID of the pipeline
+        project_id (str, optional): ID of a project; if omitted, the project
+            selected on the connection is used
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.post(
+        endpoint=(
+            f'/api/dataServer/workspaces/{workspace_id}'
+            f'/pipelines/{pipeline_id}/refresh'
+        ),
+        headers={'X-MSTR-ProjectID': project_id},
+    )
+
+
+@ErrorHandler(err_msg="Error creating a table in pipeline with ID: {pipeline_id}.")
+def create_pipeline_table(
+    connection: Connection,
+    workspace_id: str,
+    pipeline_id: str,
+    body: dict | None = None,
+    project_id: str | None = None,
+) -> Response:
+    """Create a new table in the specified pipeline.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        workspace_id (str): ID of the workspace
+        pipeline_id (str): ID of the pipeline
+        body (dict): JSON-formatted definition of the new table. The server
+            requires a typed table body: `ms-dataServerSourceTable` with
+            `'type': 'source'` (and the corresponding fields, e.g.
+            `columns`, `importSource`) or `ms-dataServerWrangleTable` with
+            `'type': 'wrangle'` (e.g. `operations`, `columns`, `children`).
+            An empty body `{}` fails with `8004d102 InvalidTypeIdException`
+            (field-verified).
+        project_id (str, optional): ID of a project; if omitted, the project
+            selected on the connection is used
+
+    Return:
+        HTTP response object. Expected status: 201
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.post(
+        endpoint=(
+            f'/api/dataServer/workspaces/{workspace_id}'
+            f'/pipelines/{pipeline_id}/tables'
+        ),
+        headers={'X-MSTR-ProjectID': project_id},
+        json=body if body is not None else {},
+    )
+
+
+@ErrorHandler(err_msg="Error getting table with ID: {table_id}.")
+def get_pipeline_table(
+    connection: Connection,
+    workspace_id: str,
+    pipeline_id: str,
+    table_id: str,
+    project_id: str | None = None,
+    show_preview_data: bool = False,
+    show_raw_data: bool = False,
+) -> Response:
+    """Retrieve a specific pipeline table by its ID.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        workspace_id (str): ID of the workspace
+        pipeline_id (str): ID of the pipeline
+        table_id (str): ID of the table
+        project_id (str, optional): ID of a project; if omitted, the project
+            selected on the connection is used
+        show_preview_data (bool, optional): whether to include preview data
+            in the response, defaults to False
+        show_raw_data (bool, optional): whether to include raw data in the
+            response, defaults to False
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.get(
+        endpoint=(
+            f'/api/dataServer/workspaces/{workspace_id}'
+            f'/pipelines/{pipeline_id}/tables/{table_id}'
+        ),
+        headers={'X-MSTR-ProjectID': project_id},
+        params={
+            'showPreviewData': show_preview_data,
+            'showRawData': show_raw_data,
+        },
+    )
+
+
+@ErrorHandler(err_msg="Error deleting table with ID: {table_id}.")
+def delete_pipeline_table(
+    connection: Connection,
+    workspace_id: str,
+    pipeline_id: str,
+    table_id: str,
+    project_id: str | None = None,
+) -> Response:
+    """Delete a specific pipeline table.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        workspace_id (str): ID of the workspace
+        pipeline_id (str): ID of the pipeline
+        table_id (str): ID of the table
+        project_id (str, optional): ID of a project; if omitted, the project
+            selected on the connection is used
+
+    Return:
+        HTTP response object. Expected status: 204
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.delete(
+        endpoint=(
+            f'/api/dataServer/workspaces/{workspace_id}'
+            f'/pipelines/{pipeline_id}/tables/{table_id}'
+        ),
+        headers={'X-MSTR-ProjectID': project_id},
+    )
+
+
+@ErrorHandler(err_msg="Error updating table with ID: {table_id}.")
+def update_pipeline_table(
+    connection: Connection,
+    workspace_id: str,
+    pipeline_id: str,
+    table_id: str,
+    body: dict,
+    project_id: str | None = None,
+) -> Response:
+    """Update an existing pipeline table. Returns the table's updated
+    definition.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        workspace_id (str): ID of the workspace
+        pipeline_id (str): ID of the pipeline
+        table_id (str): ID of the table
+        body (dict): JSON-formatted table definition update
+            (`ms-dataServerSourceTable` or `ms-dataServerWrangleTable`)
+        project_id (str, optional): ID of a project; if omitted, the project
+            selected on the connection is used
+
+    Return:
+        HTTP response object. Expected status: 200
+    """
+    if project_id is None:
+        connection._validate_project_selected()
+        project_id = connection.project_id
+    return connection.patch(
+        endpoint=(
+            f'/api/dataServer/workspaces/{workspace_id}'
+            f'/pipelines/{pipeline_id}/tables/{table_id}'
+        ),
+        headers={'X-MSTR-ProjectID': project_id},
+        json=body,
+    )

--- a/mstrio/modeling/__init__.py
+++ b/mstrio/modeling/__init__.py
@@ -7,5 +7,6 @@ from .expression import *
 from .metric import *
 from .prompt import *
 from .security_filter import *
+from .data_model import *
 
 # isort: on

--- a/mstrio/modeling/data_model/__init__.py
+++ b/mstrio/modeling/data_model/__init__.py
@@ -1,0 +1,24 @@
+# flake8: noqa
+from .helpers import (
+    DataModelFolder,
+    DataModelLink,
+    DataModelPublishStatus,
+    DataServeMode,
+    ExternalDataModel,
+    RefreshPolicy,
+    TablePublishStatus,
+)
+from .data_model_component import DataModelComponent
+from .data_model_table import DataModelTable, list_data_model_tables
+from .data_model_attribute import DataModelAttribute, list_data_model_attributes
+from .data_model_metric import (
+    DataModelFactMetric,
+    DataModelMetric,
+    list_data_model_fact_metrics,
+    list_data_model_metrics,
+)
+from .data_model_security_filter import (
+    DataModelSecurityFilter,
+    list_data_model_security_filters,
+)
+from .data_model import DataModel, list_data_models

--- a/mstrio/modeling/data_model/data_model.py
+++ b/mstrio/modeling/data_model/data_model.py
@@ -1,0 +1,1263 @@
+import copy
+import logging
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from mstrio import config
+from mstrio.api import data_models
+from mstrio.connection import Connection
+from mstrio.helpers import MstrException
+from mstrio.modeling.data_model.data_model_attribute import (
+    DataModelAttribute,
+    list_data_model_attributes,
+)
+from mstrio.modeling.data_model.data_model_metric import (
+    DataModelFactMetric,
+    DataModelMetric,
+    list_data_model_fact_metrics,
+    list_data_model_metrics,
+)
+from mstrio.modeling.data_model.data_model_security_filter import (
+    DataModelSecurityFilter,
+    list_data_model_security_filters,
+)
+from mstrio.modeling.data_model.data_model_table import (
+    DataModelTable,
+    list_data_model_tables,
+)
+from mstrio.modeling.data_model.helpers import (
+    DataModelFolder,
+    DataModelLink,
+    DataModelPublishStatus,
+    DataServeMode,
+    ExternalDataModel,
+    RefreshPolicy,
+    unpack_information_dict,
+)
+from mstrio.object_management.folder import Folder
+from mstrio.object_management.search_enums import SearchPattern
+from mstrio.object_management.search_operations import full_search
+from mstrio.types import ObjectSubTypes, ObjectTypes
+from mstrio.users_and_groups.user import User
+from mstrio.utils.api_helpers import changeset_manager
+from mstrio.utils.entity import CopyMixin, DeleteMixin, Entity, MoveMixin
+from mstrio.utils.enum_helper import get_enum_val
+from mstrio.utils.helper import (
+    Dictable,
+    delete_none_values,
+    find_object_with_name,
+    get_objects_id,
+    get_response_json,
+)
+from mstrio.utils.resolvers import (
+    FolderPathType,
+    get_project_id_from_params_set,
+    validate_owner_key_in_filters,
+)
+from mstrio.utils.response_processors import objects as objects_processors
+from mstrio.utils.version_helper import class_version_handler, method_version_handler
+
+if TYPE_CHECKING:
+    from mstrio.server.project import Project
+
+logger = logging.getLogger(__name__)
+
+
+@method_version_handler('11.6.0100')
+def list_data_models(
+    connection: Connection,
+    name: str | None = None,
+    to_dictionary: bool = False,
+    limit: int | None = None,
+    search_pattern: SearchPattern | int = SearchPattern.CONTAINS,
+    project: 'Project | str | None' = None,
+    project_id: str | None = None,
+    project_name: str | None = None,
+    folder: 'Folder | str | FolderPathType | None' = None,
+    folder_id: str | None = None,
+    folder_name: str | None = None,
+    folder_path: FolderPathType | None = None,
+    **filters,
+) -> list['DataModel'] | list[dict]:
+    """Get a list of Mosaic data models.
+
+    Note:
+        Data models share the metadata subtype 779 (`report_emma_cube`) with
+        classic EMMA super cubes; Mosaic data models are the Modeling-Service
+        view of these objects, so classic super cubes may appear in the
+        results as well.
+
+    Args:
+        connection (Connection): Strategy One connection object returned
+            by `connection.Connection()`
+        name (str, optional): value the search pattern is set to, which will
+            be applied to the names of data models being searched
+        to_dictionary (bool, optional): if True, return data models as
+            a list of dicts
+        limit (int, optional): limit the number of elements returned. If None
+            all objects are returned.
+        search_pattern (SearchPattern enum or int, optional): pattern to
+            search for, such as Begin With or Exactly. Possible values are
+            available in ENUM `mstrio.object_management.SearchPattern`.
+            Default value is CONTAINS (4).
+        project (Project | str, optional): Project object or ID or name
+            specifying the project. May be used instead of `project_id` or
+            `project_name`.
+        project_id (str, optional): Project ID
+        project_name (str, optional): Project name
+        folder (Folder | str | FolderPathType, optional): Folder object or ID
+            or name or path specifying the folder to search in
+        folder_id (str, optional): ID of a folder
+        folder_name (str, optional): Name of a folder
+        folder_path (FolderPathType, optional): Path of the folder. It can be
+            a string with "/" as path separator
+            (e.g. "folder/subfolder1/subfolder2") or a tuple or list of path
+            parts (e.g. `("folder", "subfolder1", "subfolder2")`).
+        **filters: Available filter parameters: `id`, `name`, `description`,
+            `date_created`, `date_modified`, `version`, `owner`, `acg`,
+            `subtype`, `ext_type`
+
+    Returns:
+        A list of DataModel objects or dictionaries representing them.
+    """
+    proj_id = get_project_id_from_params_set(
+        connection,
+        project,
+        project_id,
+        project_name,
+    )
+    validate_owner_key_in_filters(filters)
+    objects_ = full_search(
+        connection,
+        object_types=ObjectSubTypes.SUPER_CUBE,
+        project=proj_id,
+        name=name,
+        pattern=search_pattern,
+        root=folder,
+        root_id=folder_id,
+        root_name=folder_name,
+        root_path=folder_path,
+        limit=limit,
+        **filters,
+    )
+    if to_dictionary:
+        return objects_
+    return [
+        DataModel.from_dict(source=obj_, connection=connection, with_missing_value=True)
+        for obj_ in objects_
+    ]
+
+
+@class_version_handler('11.6.0100')
+class DataModel(Entity, CopyMixin, MoveMixin, DeleteMixin):
+    """Python representation of a Mosaic Data Model object.
+
+    Data model definitions are managed through the changeset-scoped
+    Modeling-Service endpoints (`/api/model/dataModels/...`), while
+    publishing, attribute elements and security-filter members use the
+    runtime endpoints (`/api/dataModels/...`). A 404 on one path shape
+    usually means the other shape was intended.
+
+    Attributes:
+        id: data model's ID
+        name: data model's name
+        description: data model's description
+        sub_type: string literal used to identify the type of a metadata
+            object
+        data_serve_mode: mode in which the data model serves data,
+            DataServeMode enum
+        schema_folder_id: the schema folder ID where data model objects are
+            stored
+        type: object type, ObjectTypes enum
+        subtype: object subtype, ObjectSubTypes enum
+        date_created: creation time, DateTime object
+        date_modified: last modification time, DateTime object
+        owner: User object that is the owner
+        acg: access rights
+        acl: object access control list
+        hidden: specifies whether the object is hidden
+    """
+
+    _OBJECT_TYPE = ObjectTypes.REPORT_DEFINITION
+    _OBJECT_SUBTYPES = [ObjectSubTypes.SUPER_CUBE]
+    _API_GETTERS = {
+        (
+            'id',
+            'sub_type',
+            'name',
+            'description',
+            'data_serve_mode',
+            'schema_folder_id',
+            'enable_wrangle_recommendations',
+            'enable_auto_hierarchy_relationships',
+            'sampling',
+            'partition',
+            'auto_join',
+        ): data_models.get_data_model,
+        (
+            'abbreviation',
+            'type',
+            'subtype',
+            'ext_type',
+            'date_created',
+            'date_modified',
+            'version',
+            'owner',
+            'icon_path',
+            'view_media',
+            'ancestors',
+            'certified_info',
+            'acg',
+            'acl',
+            'target_info',
+            'hidden',
+            'comments',
+        ): objects_processors.get_info,
+    }
+    _API_PATCH = {
+        (
+            'name',
+            'description',
+            'data_serve_mode',
+            'destination_folder_id',
+        ): (data_models.update_data_model, 'partial_put'),
+        (
+            'comments',
+            'owner',
+            'hidden',
+            'folder_id',
+        ): (objects_processors.update, 'partial_put'),
+    }
+    _FROM_DICT_MAP = {
+        **Entity._FROM_DICT_MAP,
+        'data_serve_mode': DataServeMode,
+    }
+
+    def __init__(
+        self,
+        connection: Connection,
+        id: str | None = None,
+        name: str | None = None,
+    ) -> None:
+        """Initialize DataModel object by passing `id` or `name`.
+
+        Args:
+            connection (Connection): Strategy One connection object returned
+                by `connection.Connection()`
+            id (str, optional): ID of the data model
+            name (str, optional): name of the data model
+
+        Note:
+            Parameter `name` is not used when fetching. If only `name`
+            parameter is provided, `id` will be found automatically if such
+            object exists.
+
+        Raises:
+            ValueError: if both `id` and `name` are not provided or if
+                DataModel with the given `name` doesn't exist.
+        """
+        if id is None:
+            if name is None:
+                raise ValueError("Please specify either 'name' or 'id'.")
+            data_model = find_object_with_name(
+                connection=connection,
+                cls=self.__class__,
+                name=name,
+                listing_function=list_data_models,
+                search_pattern=SearchPattern.EXACTLY,
+            )
+            id = data_model['id']
+        super().__init__(connection=connection, object_id=id, name=name)
+
+    def _init_variables(self, default_value=None, **kwargs) -> None:
+        super()._init_variables(default_value=default_value, **kwargs)
+        self._sub_type = kwargs.get('sub_type', default_value)
+        data_serve_mode = kwargs.get('data_serve_mode')
+        self._data_serve_mode = (
+            DataServeMode(data_serve_mode)
+            if isinstance(data_serve_mode, str)
+            else data_serve_mode
+        ) or default_value
+        self._schema_folder_id = kwargs.get('schema_folder_id', default_value)
+        self._enable_wrangle_recommendations = kwargs.get(
+            'enable_wrangle_recommendations', default_value
+        )
+        self._enable_auto_hierarchy_relationships = kwargs.get(
+            'enable_auto_hierarchy_relationships', default_value
+        )
+        self._sampling = kwargs.get('sampling', default_value)
+        self._partition = kwargs.get('partition', default_value)
+        self._auto_join = kwargs.get('auto_join', default_value)
+
+    @classmethod
+    def create(
+        cls,
+        connection: Connection,
+        name: str,
+        destination_folder: Folder | str,
+        data_serve_mode: DataServeMode | str = DataServeMode.CONNECT_LIVE,
+        description: str | None = None,
+        tables: list[dict] | None = None,
+        attributes: list[dict] | None = None,
+    ) -> 'DataModel':
+        """Create a new Mosaic data model.
+
+        Note:
+            Servers enforce a minimum committable model (field-verified):
+            the creation changeset must contain at least one table (error
+            8004e46f otherwise), every table must end up with at least one
+            attribute or metric (error 8004e42f), and every attribute must
+            carry `displays` (error 8004cf06). Provide `tables` and
+            `attributes` together so the whole minimum shape is committed
+            in one changeset.
+
+        Args:
+            connection (Connection): Strategy One connection object returned
+                by `connection.Connection()`
+            name (str): name of the data model
+            destination_folder (Folder | str): Folder object or folder ID
+                where the data model will be created
+            data_serve_mode (DataServeMode | str, optional): mode in which
+                the data model serves data, defaults to
+                `DataServeMode.CONNECT_LIVE`
+            description (str, optional): description of the data model
+            tables (list[dict], optional): definitions of logical tables to
+                add to the data model inside the same (creation) changeset;
+                each entry is an `ms-DataModelTableAdd` dict (`name`,
+                `physicalTable`, `refreshPolicy`, ...)
+            attributes (list[dict], optional): attribute definitions created
+                inside the same changeset, after the tables. Each entry is an
+                attribute body (`information`, `forms`, `keyForm`, `displays`,
+                `attributeLookupTable`, ...). Anywhere the body references a
+                logical table — `lookupTable`, `attributeLookupTable` or an
+                entry of a form expression's `tables` list — the name of a
+                table created in this call may be passed as a plain string
+                (or as a ref dict without `objectId`); it is resolved to the
+                new table's reference automatically.
+
+        Returns:
+            DataModel object.
+        """
+        folder_id = get_objects_id(destination_folder, Folder)
+        body = {
+            'name': name,
+            'description': description,
+            'destinationFolderId': folder_id,
+            'dataServeMode': get_enum_val(data_serve_mode, DataServeMode),
+        }
+        body = delete_none_values(body, recursion=False)
+        if tables is not None:
+            with changeset_manager(connection, body=body) as changeset_id:
+                response = data_models.create_data_model(
+                    connection, body=body, changeset_id=changeset_id
+                ).json()
+                new_id = response.get('id')
+                table_refs = {}
+                for table_body in tables:
+                    created = data_models.create_data_model_table(
+                        connection, new_id, table_body, changeset_id=changeset_id
+                    ).json()
+                    table_id = created.get('id') or created.get('information', {}).get(
+                        'objectId'
+                    )
+                    table_name = created.get('name') or created.get(
+                        'information', {}
+                    ).get('name')
+                    ref = {
+                        'objectId': table_id,
+                        'subType': 'logical_table',
+                        'name': table_name,
+                    }
+                    table_refs[table_name] = ref
+                    if table_body.get('name'):
+                        table_refs[table_body['name']] = ref
+                for attribute_body in attributes or []:
+                    data_models.create_data_model_attribute(
+                        connection,
+                        new_id,
+                        cls._resolve_table_refs(attribute_body, table_refs),
+                        changeset_id=changeset_id,
+                    )
+            if config.verbose:
+                logger.info(
+                    f"Successfully created data model named: '{name}' with ID: '"
+                    f"{new_id}'"
+                )
+            return cls(connection, id=new_id)
+        response = data_models.create_data_model(connection, body=body).json()
+        if config.verbose:
+            logger.info(
+                f"Successfully created data model named: '{name}' with ID: '"
+                f"{response.get('id')}'"
+            )
+        return cls.from_dict(source=response, connection=connection)
+
+    @classmethod
+    def _resolve_table_refs(cls, attribute_body: dict, table_refs: dict) -> dict:
+        """Replace by-name logical-table references in an attribute body with
+        the full references of tables created in the same changeset.
+
+        A reference is resolved when it is a plain string naming a created
+        table, or a dict without an 'objectId' whose 'name' matches one.
+        """
+
+        def resolve(node):
+            if isinstance(node, str) and node in table_refs:
+                return table_refs[node]
+            if isinstance(node, dict):
+                if not node.get('objectId') and node.get('name') in table_refs:
+                    return table_refs[node['name']]
+                return node
+            return node
+
+        body = copy.deepcopy(attribute_body)
+        for key in ('attributeLookupTable',):
+            if key in body:
+                body[key] = resolve(body[key])
+        for form in body.get('forms', []):
+            if 'lookupTable' in form:
+                form['lookupTable'] = resolve(form['lookupTable'])
+            for expression in form.get('expressions', []):
+                if 'tables' in expression:
+                    expression['tables'] = [
+                        resolve(table) for table in expression['tables']
+                    ]
+        return body
+
+    def alter(
+        self,
+        name: str | None = None,
+        description: str | None = None,
+        data_serve_mode: DataServeMode | str | None = None,
+        comments: str | None = None,
+        owner: str | User | None = None,
+    ) -> None:
+        """Alter the data model's properties.
+
+        Args:
+            name (str, optional): new name of the data model
+            description (str, optional): new description of the data model
+            data_serve_mode (DataServeMode | str, optional): new data serve
+                mode
+            comments (str, optional): long description of the data model
+            owner (str | User, optional): new owner of the data model
+        """
+        if isinstance(owner, User):
+            owner = owner.id
+        if data_serve_mode is not None:
+            data_serve_mode = get_enum_val(data_serve_mode, DataServeMode)
+        properties = {
+            'name': name,
+            'description': description,
+            'data_serve_mode': data_serve_mode,
+            'comments': comments,
+            'owner': owner,
+        }
+        self._alter_properties(**delete_none_values(properties, recursion=False))
+
+    def save_as(
+        self, name: str, destination_folder: Folder | str | None = None
+    ) -> 'DataModel':
+        """Save a copy of the data model under a new name.
+
+        Args:
+            name (str): name of the new data model
+            destination_folder (Folder | str, optional): Folder object or
+                folder ID where the copy will be saved
+
+        Returns:
+            DataModel object representing the newly created copy.
+        """
+        body = {'name': name}
+        if destination_folder:
+            body['destinationFolderId'] = get_objects_id(destination_folder, Folder)
+        response = data_models.save_data_model_as(
+            self.connection, id=self.id, body=body
+        )
+        data = response.json()
+        new_id = (
+            data.get('objectId') or data.get('id') if isinstance(data, dict) else data
+        )
+        if config.verbose:
+            logger.info(
+                f"Successfully saved data model as: '{name}' with ID: '" f"{new_id}'"
+            )
+        return DataModel(connection=self.connection, id=new_id)
+
+    def to_yaml(self, path: str | Path | None = None) -> str:
+        """Export the data model definition to YAML.
+
+        Args:
+            path (str | Path, optional): if provided, the YAML text is also
+                written to this file
+
+        Returns:
+            The YAML definition of the data model as a string.
+        """
+        response = data_models.export_data_model(self.connection, id=self.id)
+        text = response.text
+        if path:
+            Path(path).write_text(text, encoding='utf-8')
+            if config.verbose:
+                logger.info(
+                    f"Successfully exported data model with ID: '{self.id}' "
+                    f"to '{path}'."
+                )
+        return text
+
+    def restore_from_yaml(self, file: str | Path | bytes) -> bool:
+        """Restore the data model definition from a YAML export.
+
+        Args:
+            file (str | Path | bytes): path to a YAML file, or the YAML
+                content itself as bytes
+
+        Returns:
+            True on success. False otherwise.
+        """
+        if isinstance(file, bytes):
+            data, file_name = file, 'data_model.yaml'
+        else:
+            path = Path(file)
+            data, file_name = path.read_bytes(), path.name
+        response = data_models.restore_data_model(
+            self.connection, id=self.id, file=data, file_name=file_name
+        )
+        if response.ok:
+            if config.verbose:
+                logger.info(
+                    f"Successfully restored data model with ID: '{self.id}' "
+                    f"from '{file_name}'."
+                )
+            self.fetch()
+        return response.ok
+
+    # Publishing
+
+    def create_instance(self, show_invalid_cache_table_ids: bool = False) -> str:
+        """Create a new data model instance used for publishing.
+
+        Note:
+            The endpoint returns 204 with NO body; the new instance ID is
+            returned only in the `X-MSTR-DataModelInstanceId` response
+            header. Instance IDs expire after roughly 2 minutes (a 404
+            ERR004 on `get_publish_status` means the instance must be minted
+            again).
+
+        Args:
+            show_invalid_cache_table_ids (bool, optional): whether to report
+                invalid cache table IDs
+
+        Returns:
+            ID of the created instance (str).
+        """
+        response = data_models.create_data_model_instance(
+            self.connection,
+            id=self.id,
+            show_invalid_cache_table_ids=show_invalid_cache_table_ids,
+        )
+        return response.headers['X-MSTR-DataModelInstanceId']
+
+    def delete_instance(self, instance_id: str) -> bool:
+        """Delete a data model instance.
+
+        Args:
+            instance_id (str): ID of the instance to delete
+
+        Returns:
+            True on success. False otherwise.
+        """
+        response = data_models.delete_data_model_instance(
+            self.connection, id=self.id, instance_id=instance_id
+        )
+        return response.ok
+
+    def get_publish_status(self, instance_id: str) -> DataModelPublishStatus:
+        """Get the publish status of a data model instance.
+
+        Args:
+            instance_id (str): ID of the instance returned by
+                `create_instance()` / `publish(await_completion=False)`
+
+        Returns:
+            DataModelPublishStatus object. Publishing succeeded only when
+            the top-level `status` is 0 and every table's status is
+            `loaded`.
+        """
+        response = data_models.get_publish_status(
+            self.connection, id=self.id, instance_id=instance_id
+        )
+        return DataModelPublishStatus.from_dict(response.json())
+
+    def publish(
+        self,
+        refresh_policy: RefreshPolicy | str = RefreshPolicy.REPLACE,
+        tables: list['str | DataModelTable'] | None = None,
+        await_completion: bool = True,
+        timeout: int = 600,
+        polling_interval: int = 5,
+    ) -> DataModelPublishStatus | str:
+        """Publish the data model (create instance, trigger publish, poll).
+
+        Note (field-verified behavior):
+            - The publish POST returns 204 and is FIRE-AND-FORGET - never
+              report success without polling `get_publish_status`.
+            - Every logical table must be listed in the refresh settings;
+              an empty table list returns 400 "tableRefreshSettings cannot
+              be null". When `tables` is None all tables are enumerated
+              automatically.
+            - Instance IDs expire after ~2 minutes; a 404 ERR004 on the
+              status poll means a new instance must be minted and publish
+              re-triggered.
+            - A top-level status of `-2147212544` indicates a tenant-side
+              QueryEngine stall - do NOT retry in a loop; fall back to the
+              `connect_live` data serve mode instead.
+            - Publish silently no-ops when physical-table columns carry
+              warehouse-catalog sentinel dataTypes (precision -1 / scale
+              -MIN_INT).
+
+        Args:
+            refresh_policy (RefreshPolicy | str, optional): refresh policy
+                applied to all tables, defaults to `RefreshPolicy.REPLACE`
+            tables (list, optional): list of `DataModelTable` objects or
+                table IDs to publish; if None, ALL tables of the data model
+                are published
+            await_completion (bool, optional): if True (default), poll the
+                publish status until success, error or timeout
+            timeout (int, optional): maximum seconds to wait, default 600
+            polling_interval (int, optional): seconds between status polls,
+                default 5
+
+        Returns:
+            DataModelPublishStatus on success when `await_completion` is
+            True; the instance ID (str) when `await_completion` is False.
+
+        Raises:
+            MstrException: on publish error or timeout.
+        """
+        policy = get_enum_val(refresh_policy, RefreshPolicy)
+        instance_id = self.create_instance()
+        if tables is None:
+            table_ids = [
+                unpack_information_dict(table).get('id')
+                for table in data_models.list_data_model_tables(
+                    self.connection, id=self.id
+                )
+                .json()
+                .get('tables', [])
+            ]
+        else:
+            table_ids = [
+                table.id if isinstance(table, DataModelTable) else table
+                for table in tables
+            ]
+        body = {
+            'tables': [
+                {'id': table_id, 'refreshPolicy': policy} for table_id in table_ids
+            ]
+        }
+        data_models.publish_data_model(
+            self.connection, id=self.id, instance_id=instance_id, body=body
+        )
+        if not await_completion:
+            return instance_id
+        start = time.time()
+        while True:
+            status = self.get_publish_status(instance_id)
+            if status.status == 0:
+                if config.verbose:
+                    logger.info(
+                        f"Successfully published data model with ID: '" f"{self.id}'."
+                    )
+                return status
+            failed_tables = [
+                table for table in (status.tables or []) if table.status == 'error'
+            ]
+            if (status.status is not None and status.status < 0) or failed_tables:
+                raise MstrException(
+                    f"Error publishing data model with ID: '{self.id}'. "
+                    f"Status: {status.to_dict()}"
+                )
+            if time.time() - start > timeout:
+                raise MstrException(
+                    f"Timeout ({timeout}s) while publishing data model with "
+                    f"ID: '{self.id}'. Last status: {status.to_dict()}"
+                )
+            time.sleep(polling_interval)
+
+    def get_hierarchy(self) -> dict:
+        """Get the system hierarchy of the data model.
+
+        Returns:
+            Dictionary with the hierarchy definition
+            (`ms-DataModelHierarchy` schema).
+        """
+        return data_models.get_data_model_hierarchy(self.connection, id=self.id).json()
+
+    # Folders
+
+    def list_folders(
+        self,
+        offset: int | None = None,
+        limit: int | None = None,
+        to_dictionary: bool = False,
+    ) -> list[DataModelFolder] | list[dict]:
+        """List folders of the data model.
+
+        Args:
+            offset (int, optional): starting point within the collection
+            limit (int, optional): limit the number of elements returned
+            to_dictionary (bool, optional): if True, return folders as
+                a list of dicts
+
+        Returns:
+            A list of DataModelFolder objects or dictionaries representing
+            them.
+        """
+        folders = (
+            data_models.list_data_model_folders(
+                self.connection, id=self.id, offset=offset, limit=limit
+            )
+            .json()
+            .get('folders', [])
+        )
+        if to_dictionary:
+            return folders
+        return [DataModelFolder.from_dict(folder) for folder in folders]
+
+    def create_folder(
+        self, name: str, destination_folder_id: str | None = None
+    ) -> DataModelFolder:
+        """Create a new folder inside the data model.
+
+        Args:
+            name (str): name of the folder
+            destination_folder_id (str, optional): ID of the parent folder
+                inside the data model
+
+        Returns:
+            DataModelFolder object.
+        """
+        information = delete_none_values(
+            {'name': name, 'destinationFolderId': destination_folder_id},
+            recursion=False,
+        )
+        response = data_models.create_data_model_folder(
+            self.connection, id=self.id, body={'information': information}
+        )
+        if config.verbose:
+            logger.info(
+                f"Successfully created folder named: '{name}' in data model "
+                f"with ID: '{self.id}'."
+            )
+        return DataModelFolder.from_dict(get_response_json(response))
+
+    def get_folder(self, folder_id: str) -> DataModelFolder:
+        """Get a folder of the data model.
+
+        Args:
+            folder_id (str): ID of the folder
+
+        Returns:
+            DataModelFolder object.
+        """
+        response = data_models.get_data_model_folder(
+            self.connection, id=self.id, folder_id=folder_id
+        )
+        return DataModelFolder.from_dict(response.json())
+
+    def alter_folder(
+        self,
+        folder_id: str,
+        name: str | None = None,
+        destination_folder_id: str | None = None,
+    ) -> DataModelFolder:
+        """Alter a folder of the data model (rename or move).
+
+        Args:
+            folder_id (str): ID of the folder to alter
+            name (str, optional): new name of the folder
+            destination_folder_id (str, optional): ID of the new parent
+                folder
+
+        Returns:
+            DataModelFolder object after the update.
+        """
+        information = delete_none_values(
+            {'name': name, 'destinationFolderId': destination_folder_id},
+            recursion=False,
+        )
+        response = data_models.update_data_model_folder(
+            self.connection,
+            id=self.id,
+            folder_id=folder_id,
+            body={'information': information},
+        )
+        return DataModelFolder.from_dict(get_response_json(response))
+
+    def delete_folder(self, folder_id: str) -> bool:
+        """Delete a folder of the data model.
+
+        Args:
+            folder_id (str): ID of the folder to delete
+
+        Returns:
+            True on success. False otherwise.
+        """
+        response = data_models.delete_data_model_folder(
+            self.connection, id=self.id, folder_id=folder_id
+        )
+        if response.ok and config.verbose:
+            logger.info(
+                f"Successfully deleted folder with ID: '{folder_id}' from "
+                f"data model with ID: '{self.id}'."
+            )
+        return response.ok
+
+    # Links
+
+    def list_links(
+        self,
+        offset: int | None = None,
+        limit: int | None = None,
+        to_dictionary: bool = False,
+    ) -> list[DataModelLink] | list[dict]:
+        """List links of the data model.
+
+        Args:
+            offset (int, optional): starting point within the collection
+            limit (int, optional): limit the number of elements returned
+            to_dictionary (bool, optional): if True, return links as a list
+                of dicts
+
+        Returns:
+            A list of DataModelLink objects or dictionaries representing
+            them.
+        """
+        links = (
+            data_models.list_data_model_links(
+                self.connection, id=self.id, offset=offset, limit=limit
+            )
+            .json()
+            .get('links', [])
+        )
+        if to_dictionary:
+            return links
+        return [DataModelLink.from_dict(link) for link in links]
+
+    def create_link(self, link: dict | DataModelLink) -> DataModelLink:
+        """Create a new link in the data model.
+
+        Args:
+            link (dict | DataModelLink): link definition
+                (`ms-DataModelLink` schema)
+
+        Returns:
+            DataModelLink object.
+        """
+        body = link.to_dict() if isinstance(link, DataModelLink) else link
+        response = data_models.create_data_model_link(
+            self.connection, id=self.id, body=body
+        )
+        if config.verbose:
+            logger.info(
+                f"Successfully created link in data model with ID: '" f"{self.id}'."
+            )
+        return DataModelLink.from_dict(get_response_json(response))
+
+    def update_links(self, links: list[dict | DataModelLink]) -> list[DataModelLink]:
+        """Update the links of the data model.
+
+        Note:
+            The underlying endpoint is a PUT which REPLACES ALL links of the
+            data model. Omitting existing links DELETES them. Always read
+            the current list with `list_links()`, modify it and send the
+            full list back.
+
+        Args:
+            links (list): full list of link definitions (dicts or
+                `DataModelLink` objects)
+
+        Returns:
+            A list of DataModelLink objects after the update.
+        """
+        body = {
+            'links': [
+                link.to_dict() if isinstance(link, Dictable) else link for link in links
+            ]
+        }
+        response = data_models.update_data_model_links(
+            self.connection, id=self.id, body=body
+        )
+        return [
+            DataModelLink.from_dict(link)
+            for link in get_response_json(response).get('links', [])
+        ]
+
+    # External data models
+
+    def list_external_data_models(
+        self, to_dictionary: bool = False
+    ) -> list[ExternalDataModel] | list[dict]:
+        """List external data models referenced by the data model.
+
+        Args:
+            to_dictionary (bool, optional): if True, return external data
+                models as a list of dicts
+
+        Returns:
+            A list of ExternalDataModel objects or dictionaries representing
+            them.
+        """
+        external = (
+            data_models.list_external_data_models(self.connection, id=self.id)
+            .json()
+            .get('externalDataModels', [])
+        )
+        if to_dictionary:
+            return external
+        return [ExternalDataModel.from_dict(edm) for edm in external]
+
+    def add_external_data_model(
+        self,
+        base_data_model: 'DataModel | str | dict',
+        alias: str | None = None,
+        objects: list | None = None,
+    ) -> ExternalDataModel:
+        """Reference another data model as an external data model.
+
+        Args:
+            base_data_model (DataModel | str | dict): the base data model as
+                an object, its ID, or a full `ms-ObjectInfoReference` dict
+            alias (str, optional): alias of the external data model
+            objects (list, optional): external data model units
+                (`ms-ExternalDataModelUnit` schema)
+
+        Returns:
+            ExternalDataModel object.
+        """
+        if isinstance(base_data_model, dict):
+            base_reference = base_data_model
+        else:
+            base_id = (
+                base_data_model.id
+                if isinstance(base_data_model, DataModel)
+                else base_data_model
+            )
+            base_reference = {
+                'objectId': base_id,
+                'subType': 'report_emma_cube',
+            }
+        body = delete_none_values(
+            {
+                'baseDataModel': base_reference,
+                'alias': alias,
+                'objects': objects,
+            },
+            recursion=False,
+        )
+        response = data_models.create_external_data_model(
+            self.connection, id=self.id, body=body
+        )
+        if config.verbose:
+            logger.info(
+                f"Successfully added external data model to data model with "
+                f"ID: '{self.id}'."
+            )
+        return ExternalDataModel.from_dict(get_response_json(response))
+
+    def remove_external_data_model(self, external_data_model_id: str) -> bool:
+        """Remove an external data model reference.
+
+        Args:
+            external_data_model_id (str): ID of the external data model
+
+        Returns:
+            True on success. False otherwise.
+        """
+        response = data_models.delete_external_data_model(
+            self.connection,
+            id=self.id,
+            external_data_model_id=external_data_model_id,
+        )
+        if response.ok and config.verbose:
+            logger.info(
+                f"Successfully removed external data model with ID: '"
+                f"{external_data_model_id}' from data model with ID: '"
+                f"{self.id}'."
+            )
+        return response.ok
+
+    def alter_external_data_model(
+        self, external_data_model_id: str, body: dict
+    ) -> ExternalDataModel:
+        """Alter an external data model reference (partial update).
+
+        Args:
+            external_data_model_id (str): ID of the external data model
+            body (dict): changes to apply (`ms-ExternalDataModel` schema)
+
+        Returns:
+            ExternalDataModel object after the update.
+        """
+        response = data_models.update_external_data_model(
+            self.connection,
+            id=self.id,
+            external_data_model_id=external_data_model_id,
+            body=body,
+        )
+        return ExternalDataModel.from_dict(get_response_json(response))
+
+    def alter_external_data_model_object(
+        self, external_data_model_id: str, object_id: str, body: dict
+    ) -> dict:
+        """Alter a single object of an external data model reference.
+
+        Args:
+            external_data_model_id (str): ID of the external data model
+            object_id (str): ID of the object to alter
+            body (dict): changes to apply (`ms-ExternalDataModelUnit` schema)
+
+        Returns:
+            Dictionary with the updated object definition.
+        """
+        response = data_models.update_external_data_model_object(
+            self.connection,
+            id=self.id,
+            external_data_model_id=external_data_model_id,
+            object_id=object_id,
+            body=body,
+        )
+        return get_response_json(response)
+
+    def refresh_external_data_models(self) -> dict:
+        """Refresh all external data model references of the data model.
+
+        Returns:
+            Dictionary with the refreshed external data models and any
+            invalid links or objects.
+        """
+        response = data_models.refresh_external_data_models(self.connection, id=self.id)
+        return get_response_json(response)
+
+    # Object governance (ACLs and translations)
+
+    def get_object_acl(self, object_id: str, sub_type: str) -> dict:
+        """Get the ACL of an object living inside the data model.
+
+        Note:
+            The endpoint returns a 500 error when `sub_type` is missing and
+            silently returns a consistent-but-wrong facet when the subtype
+            is wrong - always pass the object's true subtype (e.g.
+            'attribute', 'metric', 'fact_metric', 'logical_table',
+            'md_security_filter').
+
+        Args:
+            object_id (str): ID of the object inside the data model
+            sub_type (str): subtype of the object
+
+        Returns:
+            Dictionary with the object's ACL definition.
+        """
+        return data_models.get_data_model_object_acl(
+            self.connection, id=self.id, object_id=object_id, sub_type=sub_type
+        ).json()
+
+    def update_object_acl(self, object_id: str, sub_type: str, acl: dict) -> dict:
+        """Update the ACL of an object living inside the data model.
+
+        Note:
+            The update is a WHOLESALE REPLACEMENT: trustees omitted from
+            `acl` lose their entries. The rights mask `255` is the server's
+            magic "Full Control" value (do not decompose it from flag
+            names). A wrong `sub_type` silently patches the wrong facet.
+
+        Args:
+            object_id (str): ID of the object inside the data model
+            sub_type (str): subtype of the object
+            acl (dict): mapping of trustee ID to rights definition, e.g.
+                `{'<trusteeId>': {'granted': 255, 'denied': 0,
+                'subType': 'user', 'inheritable': True}}`. May also be
+                passed already wrapped as `{'acl': {...}}`.
+
+        Returns:
+            Dictionary with the updated ACL definition.
+        """
+        body = acl if 'acl' in acl else {'acl': acl}
+        return data_models.update_data_model_object_acl(
+            self.connection,
+            id=self.id,
+            object_id=object_id,
+            sub_type=sub_type,
+            body=body,
+        ).json()
+
+    def get_object_translations(self, object_id: str, sub_type: str) -> dict:
+        """Get the translations of an object living inside the data model.
+
+        Args:
+            object_id (str): ID of the object inside the data model
+            sub_type (str): subtype of the object
+
+        Returns:
+            Dictionary with the object's translations.
+        """
+        return data_models.get_data_model_object_translations(
+            self.connection, id=self.id, object_id=object_id, sub_type=sub_type
+        ).json()
+
+    def update_object_translations(
+        self, object_id: str, sub_type: str, translations: dict
+    ) -> dict:
+        """Update the translations of an object living inside the data model.
+
+        Args:
+            object_id (str): ID of the object inside the data model
+            sub_type (str): subtype of the object
+            translations (dict): translations definition to send
+
+        Returns:
+            Dictionary with the updated translations.
+        """
+        return data_models.update_data_model_object_translations(
+            self.connection,
+            id=self.id,
+            object_id=object_id,
+            sub_type=sub_type,
+            body=translations,
+        ).json()
+
+    # Security filters (runtime collection)
+
+    def list_active_security_filters(
+        self,
+        offset: int | None = None,
+        limit: int | None = None,
+        to_dictionary: bool = False,
+    ) -> list[DataModelSecurityFilter] | list[dict]:
+        """List active security filters of the data model (runtime
+        endpoint).
+
+        Args:
+            offset (int, optional): starting point within the collection
+            limit (int, optional): limit the number of elements returned
+            to_dictionary (bool, optional): if True, return security filters
+                as a list of dicts
+
+        Returns:
+            A list of DataModelSecurityFilter objects or dictionaries
+            representing them.
+        """
+        security_filters = (
+            data_models.list_active_security_filters(
+                self.connection, id=self.id, offset=offset, limit=limit
+            )
+            .json()
+            .get('securityFilters', [])
+        )
+        if to_dictionary:
+            return security_filters
+        return [
+            DataModelSecurityFilter.from_dict(
+                source={**sf, 'data_model_id': self.id},
+                connection=self.connection,
+            )
+            for sf in security_filters
+        ]
+
+    # Component listing conveniences
+
+    def list_tables(
+        self, to_dictionary: bool = False, **kwargs
+    ) -> list[DataModelTable] | list[dict]:
+        """List tables of the data model. See
+        `mstrio.modeling.data_model.list_data_model_tables` for the full
+        parameter list."""
+        return list_data_model_tables(
+            self.connection, data_model=self.id, to_dictionary=to_dictionary, **kwargs
+        )
+
+    def list_attributes(
+        self, to_dictionary: bool = False, **kwargs
+    ) -> list[DataModelAttribute] | list[dict]:
+        """List attributes of the data model. See
+        `mstrio.modeling.data_model.list_data_model_attributes` for the full
+        parameter list."""
+        return list_data_model_attributes(
+            self.connection, data_model=self.id, to_dictionary=to_dictionary, **kwargs
+        )
+
+    def list_metrics(
+        self, to_dictionary: bool = False, **kwargs
+    ) -> list[DataModelMetric] | list[dict]:
+        """List metrics of the data model. See
+        `mstrio.modeling.data_model.list_data_model_metrics` for the full
+        parameter list."""
+        return list_data_model_metrics(
+            self.connection, data_model=self.id, to_dictionary=to_dictionary, **kwargs
+        )
+
+    def list_fact_metrics(
+        self, to_dictionary: bool = False, **kwargs
+    ) -> list[DataModelFactMetric] | list[dict]:
+        """List fact metrics of the data model. See
+        `mstrio.modeling.data_model.list_data_model_fact_metrics` for the
+        full parameter list."""
+        return list_data_model_fact_metrics(
+            self.connection, data_model=self.id, to_dictionary=to_dictionary, **kwargs
+        )
+
+    def list_security_filters(
+        self, to_dictionary: bool = False, **kwargs
+    ) -> list[DataModelSecurityFilter] | list[dict]:
+        """List security filters of the data model (Modeling-Service
+        collection). See
+        `mstrio.modeling.data_model.list_data_model_security_filters` for
+        the full parameter list."""
+        return list_data_model_security_filters(
+            self.connection, data_model=self.id, to_dictionary=to_dictionary, **kwargs
+        )
+
+    # Properties
+
+    @property
+    def sub_type(self) -> str | None:
+        """String literal identifying the metadata subtype of the object."""
+        return self._sub_type
+
+    @property
+    def data_serve_mode(self) -> DataServeMode | None:
+        """Mode in which the data model serves data."""
+        return self._data_serve_mode
+
+    @property
+    def schema_folder_id(self) -> str | None:
+        """The schema folder ID where data model objects are stored."""
+        return self._schema_folder_id
+
+    @property
+    def enable_wrangle_recommendations(self) -> bool | None:
+        """Whether wrangle recommendations are enabled."""
+        return self._enable_wrangle_recommendations
+
+    @property
+    def enable_auto_hierarchy_relationships(self) -> bool | None:
+        """Whether automatic hierarchy relationships are enabled."""
+        return self._enable_auto_hierarchy_relationships
+
+    @property
+    def sampling(self) -> dict | None:
+        """Sampling settings of the data model."""
+        return self._sampling
+
+    @property
+    def partition(self) -> dict | None:
+        """Partition settings of the data model."""
+        return self._partition
+
+    @property
+    def auto_join(self) -> bool | None:
+        """Whether tables without user-defined relationships are joined
+        automatically using common attributes."""
+        return self._auto_join

--- a/mstrio/modeling/data_model/data_model.py
+++ b/mstrio/modeling/data_model/data_model.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 from mstrio import config
 from mstrio.api import data_models
 from mstrio.connection import Connection
-from mstrio.helpers import MstrException
+from mstrio.helpers import MstrException, MstrTimeoutError
 from mstrio.modeling.data_model.data_model_attribute import (
     DataModelAttribute,
     list_data_model_attributes,
@@ -616,6 +616,14 @@ class DataModel(Entity, CopyMixin, MoveMixin, DeleteMixin):
             - Publish silently no-ops when physical-table columns carry
               warehouse-catalog sentinel dataTypes (precision -1 / scale
               -MIN_INT).
+            - The per-instance status can remain `1` (queued/running) even
+              after the cube has finished loading — notably when a second
+              publish is triggered while one is already running. On a
+              timeout (`MstrTimeoutError`), cross-check the authoritative
+              cube state via `mstrio.api.cubes.status` (the
+              'X-MSTR-CubeStatus' response header) before re-publishing.
+            - `connect_live` data models have no publish workflow — the
+              server rejects the publish trigger with ERR006.
 
         Args:
             refresh_policy (RefreshPolicy | str, optional): refresh policy
@@ -676,13 +684,23 @@ class DataModel(Entity, CopyMixin, MoveMixin, DeleteMixin):
             ]
             if (status.status is not None and status.status < 0) or failed_tables:
                 raise MstrException(
-                    f"Error publishing data model with ID: '{self.id}'. "
-                    f"Status: {status.to_dict()}"
+                    {
+                        'code': status.status,
+                        'message': (
+                            f"Error publishing data model with ID: '{self.id}'. "
+                            f"Status: {status.to_dict()}"
+                        ),
+                    }
                 )
             if time.time() - start > timeout:
-                raise MstrException(
-                    f"Timeout ({timeout}s) while publishing data model with "
-                    f"ID: '{self.id}'. Last status: {status.to_dict()}"
+                raise MstrTimeoutError(
+                    {
+                        'message': (
+                            f"Timeout ({timeout}s) while publishing data model "
+                            f"with ID: '{self.id}'. "
+                            f"Last status: {status.to_dict()}"
+                        )
+                    }
                 )
             time.sleep(polling_interval)
 

--- a/mstrio/modeling/data_model/data_model_attribute.py
+++ b/mstrio/modeling/data_model/data_model_attribute.py
@@ -1,0 +1,379 @@
+import logging
+from typing import TYPE_CHECKING
+
+from mstrio import config
+from mstrio.api import data_models
+from mstrio.connection import Connection
+from mstrio.modeling.data_model.data_model_component import DataModelComponent
+from mstrio.modeling.data_model.helpers import unpack_information_dict
+from mstrio.utils.helper import Dictable, delete_none_values
+from mstrio.utils.version_helper import class_version_handler, method_version_handler
+
+if TYPE_CHECKING:
+    from mstrio.modeling.data_model.data_model import DataModel
+    from mstrio.modeling.schema.attribute.smart_attribute import SmartAttribute
+
+logger = logging.getLogger(__name__)
+
+
+def _to_rest(value):
+    """Convert Dictable value objects (or lists of them) to REST dicts."""
+    if isinstance(value, Dictable):
+        return value.to_dict()
+    if isinstance(value, list):
+        return [_to_rest(item) for item in value]
+    return value
+
+
+@method_version_handler('11.6.0100')
+def list_data_model_attributes(
+    connection: Connection,
+    data_model: 'DataModel | str',
+    to_dictionary: bool = False,
+    limit: int | None = None,
+    offset: int | None = None,
+    fields: str | None = None,
+    show_expression_as: str | None = None,
+    show_derived_forms: bool | None = None,
+    show_subscription_filter_candidates_only: bool | None = None,
+    changeset_id: str | None = None,
+) -> list['DataModelAttribute'] | list[dict]:
+    """Get a list of attributes of a Mosaic data model.
+
+    Args:
+        connection (Connection): Strategy One connection object returned
+            by `connection.Connection()`
+        data_model (DataModel | str): data model object or its ID
+        to_dictionary (bool, optional): if True, return attributes as
+            a list of dicts
+        limit (int, optional): limit the number of elements returned
+        offset (int, optional): starting point within the collection
+        fields (str, optional): comma-separated top-level field whitelist
+        show_expression_as (str, optional): specify how expressions are
+            presented ('tree' or 'tokens')
+        show_derived_forms (bool, optional): whether to show derived forms
+        show_subscription_filter_candidates_only (bool, optional): whether to
+            return only subscription filter candidates
+        changeset_id (str, optional): ID of an existing changeset to read from
+
+    Returns:
+        A list of DataModelAttribute objects or dictionaries representing
+        them.
+    """
+    data_model_id = data_model if isinstance(data_model, str) else data_model.id
+    attributes = (
+        data_models.list_data_model_attributes(
+            connection,
+            id=data_model_id,
+            changeset_id=changeset_id,
+            offset=offset,
+            limit=limit,
+            fields=fields,
+            show_expression_as=show_expression_as,
+            show_derived_forms=show_derived_forms,
+            show_subscription_filter_candidates_only=(
+                show_subscription_filter_candidates_only
+            ),
+        )
+        .json()
+        .get('attributes', [])
+    )
+    if limit:
+        attributes = attributes[:limit]
+    if to_dictionary:
+        return [unpack_information_dict(attr) for attr in attributes]
+    return [
+        DataModelAttribute._from_api_source(connection, data_model_id, attr)
+        for attr in attributes
+    ]
+
+
+@class_version_handler('11.6.0100')
+class DataModelAttribute(DataModelComponent):
+    """Python representation of an attribute of a Mosaic data model."""
+
+    _ACL_SUBTYPE = 'attribute'
+    _GET_FUNC = staticmethod(data_models.get_data_model_attribute)
+    _DELETE_FUNC = staticmethod(data_models.delete_data_model_attribute)
+    _ID_KWARG = 'attribute_id'
+
+    @classmethod
+    def create(
+        cls,
+        connection: Connection,
+        data_model: 'DataModel | str',
+        name: str,
+        forms: list,
+        key_form: 'Dictable | dict | None' = None,
+        displays: 'Dictable | dict | None' = None,
+        description: str | None = None,
+        attribute_lookup_table: 'Dictable | dict | None' = None,
+        sorts: 'Dictable | dict | None' = None,
+        definition: dict | None = None,
+        show_expression_as: str | None = None,
+        allow_link: bool | None = None,
+        show_derived_forms: bool | None = None,
+    ) -> 'DataModelAttribute':
+        """Create a new attribute in a Mosaic data model.
+
+        Args:
+            connection (Connection): Strategy One connection object returned
+                by `connection.Connection()`
+            data_model (DataModel | str): data model object or its ID
+            name (str): name of the attribute
+            forms (list): attribute forms; `AttributeForm`-like value objects
+                from `mstrio.modeling.schema` or plain dicts matching the
+                `ms-DataModelAttributeForm` schema
+            key_form (FormReference | dict, optional): key form reference
+            displays (AttributeDisplays | dict, optional): report and browse
+                displays of the attribute
+            description (str, optional): description of the attribute
+            attribute_lookup_table (SchemaObjectReference | dict, optional):
+                lookup table reference
+            sorts (AttributeSorts | dict, optional): report and browse sorts
+            definition (dict, optional): additional top-level body keys of the
+                `ms-DataModelAttribute` schema merged into the request body
+                (e.g. `isTimezoneAware`)
+            show_expression_as (str, optional): specify how expressions are
+                presented in the response ('tree' or 'tokens')
+            allow_link (bool, optional): whether to allow linking
+            show_derived_forms (bool, optional): whether to show derived forms
+
+        Returns:
+            DataModelAttribute object.
+        """
+        data_model_id = data_model if isinstance(data_model, str) else data_model.id
+        body = {
+            'name': name,
+            'description': description,
+            'forms': _to_rest(forms),
+            'keyForm': _to_rest(key_form),
+            'displays': _to_rest(displays),
+            'attributeLookupTable': _to_rest(attribute_lookup_table),
+            'sorts': _to_rest(sorts),
+            **(definition or {}),
+        }
+        body = delete_none_values(body, recursion=False)
+        response = data_models.create_data_model_attribute(
+            connection,
+            id=data_model_id,
+            body=body,
+            show_expression_as=show_expression_as,
+            allow_link=allow_link,
+            show_derived_forms=show_derived_forms,
+        ).json()
+        if config.verbose:
+            logger.info(
+                f"Successfully created attribute named: '{name}' with ID: '"
+                f"{response.get('id')}' in data model '{data_model_id}'."
+            )
+        return cls._from_api_source(connection, data_model_id, response)
+
+    def alter(
+        self,
+        name: str | None = None,
+        description: str | None = None,
+        forms: list | None = None,
+        key_form: 'Dictable | dict | None' = None,
+        displays: 'Dictable | dict | None' = None,
+        sorts: 'Dictable | dict | None' = None,
+        definition: dict | None = None,
+    ) -> None:
+        """Alter the attribute (partial update via PATCH).
+
+        Args:
+            name (str, optional): new name of the attribute
+            description (str, optional): new description of the attribute
+            forms (list, optional): new attribute forms
+            key_form (FormReference | dict, optional): new key form reference
+            displays (AttributeDisplays | dict, optional): new displays
+            sorts (AttributeSorts | dict, optional): new sorts
+            definition (dict, optional): additional top-level body keys merged
+                into the request body
+        """
+        body = {
+            'name': name,
+            'description': description,
+            'forms': _to_rest(forms),
+            'keyForm': _to_rest(key_form),
+            'displays': _to_rest(displays),
+            'sorts': _to_rest(sorts),
+            **(definition or {}),
+        }
+        body = delete_none_values(body, recursion=False)
+        response = data_models.update_data_model_attribute(
+            self.connection,
+            id=self.data_model_id,
+            attribute_id=self.id,
+            body=body,
+        )
+        self._set_object_attributes(**unpack_information_dict(response.json()))
+        if config.verbose:
+            logger.info(
+                f"Successfully altered attribute with ID: '{self.id}' in data "
+                f"model '{self.data_model_id}'."
+            )
+
+    def list_relationships(self) -> dict:
+        """Get the relationships of the attribute.
+
+        Returns:
+            Dictionary with a `relationships` list
+            (`ms-AttributeRelationships` schema).
+        """
+        return data_models.get_data_model_attribute_relationships(
+            self.connection, id=self.data_model_id, attribute_id=self.id
+        ).json()
+
+    def update_relationships(self, relationships: dict | list) -> dict:
+        """Update the relationships of the attribute.
+
+        Note:
+            The underlying endpoint is a PUT which REPLACES the attribute's
+            ENTIRE relationship list. Omitting existing relationships DELETES
+            them. Always read the current list with `list_relationships()`,
+            modify it and send the full list back (read-modify-write).
+
+        Args:
+            relationships (dict | list): either the full
+                `ms-AttributeRelationships` body (`{'relationships': [...]}`)
+                or a plain list of relationship dicts
+
+        Returns:
+            Dictionary with the updated `relationships` list.
+        """
+        body = (
+            relationships
+            if isinstance(relationships, dict)
+            else {'relationships': _to_rest(relationships)}
+        )
+        return data_models.update_data_model_attribute_relationships(
+            self.connection, id=self.data_model_id, attribute_id=self.id, body=body
+        ).json()
+
+    def list_elements(
+        self,
+        offset: int | None = None,
+        limit: int | None = None,
+        search_pattern: str | None = None,
+        element_id_format: str | None = None,
+    ) -> list[dict]:
+        """List elements of the attribute (runtime endpoint).
+
+        Args:
+            offset (int, optional): starting point within the collection
+            limit (int, optional): limit the number of elements returned
+            search_pattern (str, optional): pattern the element names are
+                matched against
+            element_id_format (str, optional): format of the returned element
+                IDs
+
+        Returns:
+            A list of dictionaries with element `name` and `id`.
+        """
+        return data_models.get_data_model_attribute_elements(
+            self.connection,
+            id=self.data_model_id,
+            attribute_id=self.id,
+            offset=offset,
+            limit=limit,
+            search_pattern=search_pattern,
+            element_id_format=element_id_format,
+        ).json()
+
+    def list_smart_attributes(
+        self, to_dictionary: bool = False
+    ) -> list['SmartAttribute'] | list[dict]:
+        """List smart attributes generated for this attribute.
+
+        Args:
+            to_dictionary (bool, optional): if True, return smart attributes
+                as a list of dicts
+
+        Returns:
+            A list of SmartAttribute objects or dictionaries representing
+            them.
+        """
+        from mstrio.api import smart_attributes as smart_attributes_api
+
+        response = smart_attributes_api.list_data_model_smart_attributes(
+            self.connection,
+            data_model_id=self.data_model_id,
+            attribute_id=self.id,
+        )
+        objects_ = response.json().get('smartAttributes', [])
+        if to_dictionary:
+            return objects_
+        from mstrio.modeling.schema.attribute.smart_attribute import SmartAttribute
+
+        return [
+            SmartAttribute.from_dict(source=obj, connection=self.connection)
+            for obj in objects_
+        ]
+
+    def list_smart_attribute_templates(
+        self, to_dictionary: bool = False
+    ) -> list['SmartAttribute'] | list[dict]:
+        """List smart attribute templates available for this attribute.
+
+        Args:
+            to_dictionary (bool, optional): if True, return templates as
+                a list of dicts
+
+        Returns:
+            A list of SmartAttribute objects or dictionaries representing
+            them.
+        """
+        from mstrio.api import smart_attributes as smart_attributes_api
+
+        response = smart_attributes_api.list_data_model_smart_attribute_templates(
+            self.connection,
+            data_model_id=self.data_model_id,
+            attribute_id=self.id,
+        )
+        objects_ = response.json().get('smartAttributesTemplates', [])
+        if to_dictionary:
+            return objects_
+        from mstrio.modeling.schema.attribute.smart_attribute import SmartAttribute
+
+        return [
+            SmartAttribute.from_dict(source=obj, connection=self.connection)
+            for obj in objects_
+        ]
+
+    def update_smart_attributes(
+        self, smart_attributes: list | None = None
+    ) -> list['SmartAttribute']:
+        """Update the smart attributes of this attribute.
+
+        Note:
+            The PUT is a reconcile/merge: applicable entries are merged into
+            the service-managed set. Passing `None` (or an empty list) lets
+            the service regenerate the smart attributes.
+
+        Args:
+            smart_attributes (list, optional): list of `SmartAttribute`
+                objects or dicts matching the `ms-SmartAttribute` schema
+
+        Returns:
+            A list of SmartAttribute objects after the update.
+        """
+        from mstrio.api import smart_attributes as smart_attributes_api
+
+        body = (
+            {}
+            if smart_attributes is None
+            else {'smartAttributes': _to_rest(smart_attributes)}
+        )
+        response = smart_attributes_api.update_data_model_smart_attributes(
+            self.connection,
+            data_model_id=self.data_model_id,
+            attribute_id=self.id,
+            body=body,
+        )
+        from mstrio.modeling.schema.attribute.smart_attribute import SmartAttribute
+
+        return [
+            SmartAttribute.from_dict(source=obj, connection=self.connection)
+            for obj in response.json().get('smartAttributes', [])
+        ]

--- a/mstrio/modeling/data_model/data_model_component.py
+++ b/mstrio/modeling/data_model/data_model_component.py
@@ -1,0 +1,199 @@
+import logging
+from typing import Callable
+
+from mstrio import config
+from mstrio.api import data_models
+from mstrio.connection import Connection
+from mstrio.modeling.data_model.helpers import unpack_information_dict
+from mstrio.utils.entity import EntityBase
+
+logger = logging.getLogger(__name__)
+
+
+class DataModelComponent(EntityBase):
+    """Base class for objects living inside a Mosaic data model.
+
+    Components (tables, attributes, metrics, fact metrics, security filters)
+    are addressed by the pair (`data_model_id`, `id`) and are managed through
+    the changeset-scoped Modeling-Service endpoints
+    `/api/model/dataModels/{dataModelId}/...`.
+
+    Class attributes (set per subclass):
+        _ACL_SUBTYPE (str): the `subType` query param value used by the
+            object ACL / translations endpoints, e.g. 'logical_table'
+        _GET_FUNC (Callable): api function fetching a single component
+        _DELETE_FUNC (Callable): api function deleting a single component
+        _ID_KWARG (str): name of the component id keyword argument of
+            `_GET_FUNC` / `_DELETE_FUNC`, e.g. 'table_id'
+    """
+
+    _ACL_SUBTYPE: str | None = None
+    _GET_FUNC: Callable | None = None
+    _DELETE_FUNC: Callable | None = None
+    _ID_KWARG: str = 'id'
+    _DELETE_PROMPT_ANSWER: str = 'Y'
+
+    def __init__(self, connection: Connection, data_model_id: str, id: str) -> None:
+        """Initialize the component object.
+
+        Args:
+            connection (Connection): Strategy One connection object returned
+                by `connection.Connection()`
+            data_model_id (str): ID of the data model containing the component
+            id (str): ID of the component
+        """
+        if not data_model_id:
+            raise ValueError("Please specify the 'data_model_id' parameter.")
+        if not id:
+            raise ValueError("Please specify the 'id' parameter.")
+        self._init_variables(connection=connection, id=id, data_model_id=data_model_id)
+        if config.fetch_on_init and type(self)._GET_FUNC is not None:
+            self.fetch()
+        if config.verbose:
+            logger.info(self)
+
+    def _init_variables(self, default_value=None, **kwargs) -> None:
+        super()._init_variables(default_value=default_value, **kwargs)
+        self.data_model_id = kwargs.get('data_model_id', default_value)
+        self.description = kwargs.get('description', default_value)
+        self._sub_type = kwargs.get('sub_type', default_value)
+
+    def fetch(self, attr: str | None = None) -> None:
+        """Fetch the latest component definition from the I-Server.
+
+        Args:
+            attr (str, optional): ignored; present for compatibility with the
+                `EntityBase` interface. The whole definition is always fetched.
+        """
+        func = type(self)._GET_FUNC
+        if func is None:
+            raise NotImplementedError(
+                f"{type(self).__name__} does not support fetching."
+            )
+        response = func(
+            self.connection, id=self.data_model_id, **{self._ID_KWARG: self.id}
+        )
+        data = unpack_information_dict(response.json())
+        self._set_object_attributes(**data)
+        self._add_to_fetched('id')
+
+    def delete(self, force: bool = False) -> bool:
+        """Delete the component from the data model.
+
+        Args:
+            force (bool, optional): if True, no additional prompt will be
+                shown before deleting the object
+
+        Returns:
+            True on success. False otherwise.
+        """
+        func = type(self)._DELETE_FUNC
+        if func is None:
+            raise NotImplementedError(
+                f"{type(self).__name__} does not support deleting."
+            )
+        object_name = type(self).__name__
+        if not force:
+            message = (
+                f"Are you sure you want to delete {object_name} "
+                f"'{self.name}' with ID: {self._id}? [Y/N]: "
+            )
+            if input(message) != self._DELETE_PROMPT_ANSWER:
+                return False
+        response = func(
+            self.connection, id=self.data_model_id, **{self._ID_KWARG: self.id}
+        )
+        if response.ok and config.verbose:
+            logger.info(f"Successfully deleted {object_name} with ID: '{self._id}'.")
+        return response.ok
+
+    def get_acl(self) -> dict:
+        """Get the access control list of the component.
+
+        Note:
+            The endpoint returns a 500 error when the `subType` query param is
+            missing and silently returns a consistent-but-wrong facet when it
+            is wrong; the correct value is derived from `_ACL_SUBTYPE`.
+
+        Returns:
+            Dictionary with the component's ACL definition.
+        """
+        return data_models.get_data_model_object_acl(
+            self.connection,
+            id=self.data_model_id,
+            object_id=self.id,
+            sub_type=self._ACL_SUBTYPE,
+        ).json()
+
+    def update_acl(self, acl: dict) -> dict:
+        """Update the access control list of the component.
+
+        Note:
+            The update is a WHOLESALE REPLACEMENT: trustees omitted from `acl`
+            lose their entries. Read the current ACL with `get_acl()`, modify
+            it and send the full mapping back. The rights mask `255` is the
+            server's magic "Full Control" value.
+
+        Args:
+            acl (dict): mapping of trustee ID to rights definition, e.g.
+                `{'<trusteeId>': {'granted': 255, 'denied': 0,
+                'subType': 'user', 'inheritable': True}}`. May also be passed
+                already wrapped as `{'acl': {...}}`.
+
+        Returns:
+            Dictionary with the updated ACL definition.
+        """
+        body = acl if 'acl' in acl else {'acl': acl}
+        return data_models.update_data_model_object_acl(
+            self.connection,
+            id=self.data_model_id,
+            object_id=self.id,
+            sub_type=self._ACL_SUBTYPE,
+            body=body,
+        ).json()
+
+    def get_translations(self) -> dict:
+        """Get the translations of the component.
+
+        Returns:
+            Dictionary with the component's translations.
+        """
+        return data_models.get_data_model_object_translations(
+            self.connection,
+            id=self.data_model_id,
+            object_id=self.id,
+            sub_type=self._ACL_SUBTYPE,
+        ).json()
+
+    def update_translations(self, translations: dict) -> dict:
+        """Update the translations of the component.
+
+        Args:
+            translations (dict): translations definition to send
+
+        Returns:
+            Dictionary with the updated translations.
+        """
+        return data_models.update_data_model_object_translations(
+            self.connection,
+            id=self.data_model_id,
+            object_id=self.id,
+            sub_type=self._ACL_SUBTYPE,
+            body=translations,
+        ).json()
+
+    @classmethod
+    def _from_api_source(
+        cls, connection: Connection, data_model_id: str, source: dict
+    ) -> 'DataModelComponent':
+        """Build a component from a raw REST payload, injecting the data
+        model scope."""
+        return cls.from_dict(
+            source={**unpack_information_dict(source), 'data_model_id': data_model_id},
+            connection=connection,
+        )
+
+    @property
+    def sub_type(self) -> str | None:
+        """String literal identifying the metadata subtype of the object."""
+        return self._sub_type

--- a/mstrio/modeling/data_model/data_model_metric.py
+++ b/mstrio/modeling/data_model/data_model_metric.py
@@ -1,0 +1,462 @@
+import logging
+from typing import TYPE_CHECKING
+
+from mstrio import config
+from mstrio.api import data_models
+from mstrio.connection import Connection
+from mstrio.modeling.data_model.data_model_component import DataModelComponent
+from mstrio.modeling.data_model.helpers import unpack_information_dict
+from mstrio.utils.helper import delete_none_values
+from mstrio.utils.version_helper import class_version_handler, method_version_handler
+
+if TYPE_CHECKING:
+    from mstrio.modeling.data_model.data_model import DataModel
+
+logger = logging.getLogger(__name__)
+
+
+@method_version_handler('11.6.0100')
+def list_data_model_metrics(
+    connection: Connection,
+    data_model: 'DataModel | str',
+    to_dictionary: bool = False,
+    limit: int | None = None,
+    offset: int | None = None,
+    show_expression_as: str | None = None,
+    show_filter_tokens: bool | None = None,
+    fields: str | None = None,
+    changeset_id: str | None = None,
+) -> list['DataModelMetric'] | list[dict]:
+    """Get a list of metrics of a Mosaic data model.
+
+    Args:
+        connection (Connection): Strategy One connection object returned
+            by `connection.Connection()`
+        data_model (DataModel | str): data model object or its ID
+        to_dictionary (bool, optional): if True, return metrics as
+            a list of dicts
+        limit (int, optional): limit the number of elements returned
+        offset (int, optional): starting point within the collection
+        show_expression_as (str, optional): specify how expressions are
+            presented ('tree' or 'tokens')
+        show_filter_tokens (bool, optional): whether to show filter
+            expressions as tokens
+        fields (str, optional): comma-separated top-level field whitelist
+        changeset_id (str, optional): ID of an existing changeset to read from
+
+    Returns:
+        A list of DataModelMetric objects or dictionaries representing them.
+    """
+    data_model_id = data_model if isinstance(data_model, str) else data_model.id
+    metrics = (
+        data_models.list_data_model_metrics(
+            connection,
+            id=data_model_id,
+            changeset_id=changeset_id,
+            offset=offset,
+            limit=limit,
+            show_expression_as=show_expression_as,
+            show_filter_tokens=show_filter_tokens,
+            fields=fields,
+        )
+        .json()
+        .get('metrics', [])
+    )
+    if limit:
+        metrics = metrics[:limit]
+    if to_dictionary:
+        return [unpack_information_dict(metric) for metric in metrics]
+    return [
+        DataModelMetric._from_api_source(connection, data_model_id, metric)
+        for metric in metrics
+    ]
+
+
+@method_version_handler('11.6.0100')
+def list_data_model_fact_metrics(
+    connection: Connection,
+    data_model: 'DataModel | str',
+    to_dictionary: bool = False,
+    limit: int | None = None,
+    offset: int | None = None,
+    show_expression_as: str | None = None,
+    fields: str | None = None,
+    changeset_id: str | None = None,
+) -> list['DataModelFactMetric'] | list[dict]:
+    """Get a list of fact metrics of a Mosaic data model.
+
+    Args:
+        connection (Connection): Strategy One connection object returned
+            by `connection.Connection()`
+        data_model (DataModel | str): data model object or its ID
+        to_dictionary (bool, optional): if True, return fact metrics as
+            a list of dicts
+        limit (int, optional): limit the number of elements returned
+        offset (int, optional): starting point within the collection
+        show_expression_as (str, optional): specify how expressions are
+            presented ('tree' or 'tokens')
+        fields (str, optional): comma-separated top-level field whitelist
+        changeset_id (str, optional): ID of an existing changeset to read from
+
+    Returns:
+        A list of DataModelFactMetric objects or dictionaries representing
+        them.
+    """
+    data_model_id = data_model if isinstance(data_model, str) else data_model.id
+    fact_metrics = (
+        data_models.list_data_model_fact_metrics(
+            connection,
+            id=data_model_id,
+            changeset_id=changeset_id,
+            offset=offset,
+            limit=limit,
+            show_expression_as=show_expression_as,
+            fields=fields,
+        )
+        .json()
+        .get('factMetrics', [])
+    )
+    if limit:
+        fact_metrics = fact_metrics[:limit]
+    if to_dictionary:
+        return [unpack_information_dict(metric) for metric in fact_metrics]
+    return [
+        DataModelFactMetric._from_api_source(connection, data_model_id, metric)
+        for metric in fact_metrics
+    ]
+
+
+@class_version_handler('11.6.0100')
+class DataModelMetric(DataModelComponent):
+    """Python representation of an (advanced) metric of a Mosaic data
+    model."""
+
+    _ACL_SUBTYPE = 'metric'
+    _GET_FUNC = staticmethod(data_models.get_data_model_metric)
+    _DELETE_FUNC = staticmethod(data_models.delete_data_model_metric)
+    _ID_KWARG = 'metric_id'
+
+    @classmethod
+    def create(
+        cls,
+        connection: Connection,
+        data_model: 'DataModel | str',
+        name: str,
+        expression: dict | None = None,
+        description: str | None = None,
+        definition: dict | None = None,
+        show_expression_as: str | None = None,
+        show_filter_tokens: bool | None = None,
+        show_advanced_properties: bool | None = None,
+    ) -> 'DataModelMetric':
+        """Create a new metric in a Mosaic data model.
+
+        Args:
+            connection (Connection): Strategy One connection object returned
+                by `connection.Connection()`
+            data_model (DataModel | str): data model object or its ID
+            name (str): name of the metric
+            expression (dict, optional): metric expression
+                (`ms-Expression` schema)
+            description (str, optional): description of the metric
+            definition (dict, optional): additional top-level body keys of the
+                `ms-AdvancedMetric` schema merged into the request body (e.g.
+                `dimty`, `conditionality`, `metricSubtotals`)
+            show_expression_as (str, optional): specify how expressions are
+                presented in the response ('tree' or 'tokens')
+            show_filter_tokens (bool, optional): whether to show filter
+                expressions as tokens
+            show_advanced_properties (bool, optional): whether to show
+                advanced properties in the response
+
+        Returns:
+            DataModelMetric object.
+        """
+        data_model_id = data_model if isinstance(data_model, str) else data_model.id
+        body = {
+            'name': name,
+            'description': description,
+            'expression': expression,
+            **(definition or {}),
+        }
+        body = delete_none_values(body, recursion=False)
+        response = data_models.create_data_model_metric(
+            connection,
+            id=data_model_id,
+            body=body,
+            show_expression_as=show_expression_as,
+            show_filter_tokens=show_filter_tokens,
+            show_advanced_properties=show_advanced_properties,
+        ).json()
+        if config.verbose:
+            logger.info(
+                f"Successfully created metric named: '{name}' with ID: '"
+                f"{response.get('id')}' in data model '{data_model_id}'."
+            )
+        return cls._from_api_source(connection, data_model_id, response)
+
+    def alter(
+        self,
+        name: str | None = None,
+        description: str | None = None,
+        expression: dict | None = None,
+        definition: dict | None = None,
+    ) -> None:
+        """Alter the metric.
+
+        Note:
+            The underlying endpoint is a PUT (full replace). This method
+            first fetches the current definition and merges the requested
+            changes into it before sending, so unspecified fields are
+            preserved.
+
+        Args:
+            name (str, optional): new name of the metric
+            description (str, optional): new description of the metric
+            expression (dict, optional): new metric expression
+            definition (dict, optional): additional top-level body keys merged
+                into the request body
+        """
+        current = (
+            type(self)
+            ._GET_FUNC(self.connection, id=self.data_model_id, metric_id=self.id)
+            .json()
+        )
+        body = {key: val for key, val in current.items() if key != 'id'}
+        changes = {
+            'name': name,
+            'description': description,
+            'expression': expression,
+            **(definition or {}),
+        }
+        body.update(delete_none_values(changes, recursion=False))
+        response = data_models.update_data_model_metric(
+            self.connection, id=self.data_model_id, metric_id=self.id, body=body
+        )
+        self._set_object_attributes(**unpack_information_dict(response.json()))
+        if config.verbose:
+            logger.info(
+                f"Successfully altered metric with ID: '{self.id}' in data "
+                f"model '{self.data_model_id}'."
+            )
+
+    def get_applicable_advanced_properties(
+        self, show_sql_preview: bool | None = None
+    ) -> dict:
+        """Get the advanced (VLDB) properties applicable to the metric.
+
+        Args:
+            show_sql_preview (bool, optional): whether to include a SQL
+                preview in the response
+
+        Returns:
+            Dictionary with the applicable advanced properties.
+        """
+        return data_models.get_metric_applicable_advanced_properties(
+            self.connection,
+            id=self.data_model_id,
+            metric_id=self.id,
+            show_sql_preview=show_sql_preview,
+        ).json()
+
+    def create_embedded_object(
+        self,
+        body: dict,
+        show_expression_as: str | None = None,
+        show_filter_tokens: bool | None = None,
+    ) -> dict:
+        """Create an embedded object of the metric.
+
+        Args:
+            body (dict): embedded object definition
+                (`ms-DataModelEmbeddedObject` schema)
+            show_expression_as (str, optional): specify how expressions are
+                presented in the response ('tree' or 'tokens')
+            show_filter_tokens (bool, optional): whether to show filter
+                expressions as tokens
+
+        Returns:
+            Dictionary with the created embedded object.
+        """
+        return data_models.create_metric_embedded_object(
+            self.connection,
+            id=self.data_model_id,
+            metric_id=self.id,
+            body=body,
+            show_expression_as=show_expression_as,
+            show_filter_tokens=show_filter_tokens,
+        ).json()
+
+    def get_embedded_object(
+        self,
+        embedded_object_id: str,
+        show_expression_as: str | None = None,
+        show_filter_tokens: bool | None = None,
+    ) -> dict:
+        """Get an embedded object of the metric.
+
+        Args:
+            embedded_object_id (str): ID of the embedded object
+            show_expression_as (str, optional): specify how expressions are
+                presented ('tree' or 'tokens')
+            show_filter_tokens (bool, optional): whether to show filter
+                expressions as tokens
+
+        Returns:
+            Dictionary with the embedded object definition.
+        """
+        return data_models.get_metric_embedded_object(
+            self.connection,
+            id=self.data_model_id,
+            metric_id=self.id,
+            embedded_object_id=embedded_object_id,
+            show_expression_as=show_expression_as,
+            show_filter_tokens=show_filter_tokens,
+        ).json()
+
+    def update_embedded_object(
+        self,
+        embedded_object_id: str,
+        body: dict,
+        show_expression_as: str | None = None,
+        show_filter_tokens: bool | None = None,
+    ) -> dict:
+        """Update an embedded object of the metric (PUT, full replace).
+
+        Args:
+            embedded_object_id (str): ID of the embedded object
+            body (dict): full embedded object definition
+            show_expression_as (str, optional): specify how expressions are
+                presented in the response ('tree' or 'tokens')
+            show_filter_tokens (bool, optional): whether to show filter
+                expressions as tokens
+
+        Returns:
+            Dictionary with the updated embedded object.
+        """
+        return data_models.update_metric_embedded_object(
+            self.connection,
+            id=self.data_model_id,
+            metric_id=self.id,
+            embedded_object_id=embedded_object_id,
+            body=body,
+            show_expression_as=show_expression_as,
+            show_filter_tokens=show_filter_tokens,
+        ).json()
+
+
+@class_version_handler('11.6.0100')
+class DataModelFactMetric(DataModelComponent):
+    """Python representation of a fact metric of a Mosaic data model."""
+
+    _ACL_SUBTYPE = 'fact_metric'
+    _GET_FUNC = staticmethod(data_models.get_data_model_fact_metric)
+    _DELETE_FUNC = staticmethod(data_models.delete_data_model_fact_metric)
+    _ID_KWARG = 'fact_metric_id'
+
+    @classmethod
+    def create(
+        cls,
+        connection: Connection,
+        data_model: 'DataModel | str',
+        name: str,
+        fact: dict | None = None,
+        function: str | None = None,
+        description: str | None = None,
+        definition: dict | None = None,
+        show_expression_as: str | None = None,
+        show_advanced_properties: bool | None = None,
+        allow_link: bool | None = None,
+    ) -> 'DataModelFactMetric':
+        """Create a new fact metric in a Mosaic data model.
+
+        Note:
+            This endpoint also creates compound, conditional and
+            transformation metrics - the differentiator is which top-level
+            body keys are set (e.g. `fact` + `function` for a plain fact
+            metric, `conditionality` for a conditional one, ...). Use the
+            `definition` parameter for the extra keys.
+
+        Args:
+            connection (Connection): Strategy One connection object returned
+                by `connection.Connection()`
+            data_model (DataModel | str): data model object or its ID
+            name (str): name of the fact metric
+            fact (dict, optional): managed fact definition
+                (`ms-ManagedFact` schema)
+            function (str, optional): aggregation function, e.g. 'sum'
+            description (str, optional): description of the fact metric
+            definition (dict, optional): additional top-level body keys of the
+                `ms-FactMetric` schema merged into the request body (e.g.
+                `dimty`, `conditionality`, `functionProperties`)
+            show_expression_as (str, optional): specify how expressions are
+                presented in the response ('tree' or 'tokens')
+            show_advanced_properties (bool, optional): whether to show
+                advanced properties in the response
+            allow_link (bool, optional): whether to allow linking
+
+        Returns:
+            DataModelFactMetric object.
+        """
+        data_model_id = data_model if isinstance(data_model, str) else data_model.id
+        body = {
+            'name': name,
+            'description': description,
+            'fact': fact,
+            'function': function,
+            **(definition or {}),
+        }
+        body = delete_none_values(body, recursion=False)
+        response = data_models.create_data_model_fact_metric(
+            connection,
+            id=data_model_id,
+            body=body,
+            show_expression_as=show_expression_as,
+            show_advanced_properties=show_advanced_properties,
+            allow_link=allow_link,
+        ).json()
+        if config.verbose:
+            logger.info(
+                f"Successfully created fact metric named: '{name}' with ID: '"
+                f"{response.get('id')}' in data model '{data_model_id}'."
+            )
+        return cls._from_api_source(connection, data_model_id, response)
+
+    def alter(
+        self,
+        name: str | None = None,
+        description: str | None = None,
+        fact: dict | None = None,
+        function: str | None = None,
+        definition: dict | None = None,
+    ) -> None:
+        """Alter the fact metric (partial update via PATCH).
+
+        Args:
+            name (str, optional): new name of the fact metric
+            description (str, optional): new description of the fact metric
+            fact (dict, optional): new managed fact definition
+            function (str, optional): new aggregation function
+            definition (dict, optional): additional top-level body keys merged
+                into the request body
+        """
+        body = {
+            'name': name,
+            'description': description,
+            'fact': fact,
+            'function': function,
+            **(definition or {}),
+        }
+        body = delete_none_values(body, recursion=False)
+        response = data_models.update_data_model_fact_metric(
+            self.connection,
+            id=self.data_model_id,
+            fact_metric_id=self.id,
+            body=body,
+        )
+        self._set_object_attributes(**unpack_information_dict(response.json()))
+        if config.verbose:
+            logger.info(
+                f"Successfully altered fact metric with ID: '{self.id}' in "
+                f"data model '{self.data_model_id}'."
+            )

--- a/mstrio/modeling/data_model/data_model_security_filter.py
+++ b/mstrio/modeling/data_model/data_model_security_filter.py
@@ -1,0 +1,313 @@
+import logging
+from typing import TYPE_CHECKING
+
+from mstrio import config
+from mstrio.api import data_models
+from mstrio.connection import Connection
+from mstrio.modeling.data_model.data_model_component import DataModelComponent
+from mstrio.modeling.data_model.helpers import unpack_information_dict
+from mstrio.utils.helper import delete_none_values
+from mstrio.utils.version_helper import class_version_handler, method_version_handler
+
+if TYPE_CHECKING:
+    from mstrio.modeling.data_model.data_model import DataModel
+    from mstrio.users_and_groups import UserOrGroup
+
+logger = logging.getLogger(__name__)
+
+_USER_SUBTYPE = 8704
+_USER_GROUP_SUBTYPE = 8705
+
+
+@method_version_handler('11.6.0100')
+def list_data_model_security_filters(
+    connection: Connection,
+    data_model: 'DataModel | str',
+    to_dictionary: bool = False,
+    limit: int | None = None,
+    offset: int | None = None,
+    changeset_id: str | None = None,
+) -> list['DataModelSecurityFilter'] | list[dict]:
+    """Get a list of security filters of a Mosaic data model (Modeling-Service
+    collection).
+
+    Args:
+        connection (Connection): Strategy One connection object returned
+            by `connection.Connection()`
+        data_model (DataModel | str): data model object or its ID
+        to_dictionary (bool, optional): if True, return security filters as
+            a list of dicts
+        limit (int, optional): limit the number of elements returned
+        offset (int, optional): starting point within the collection
+        changeset_id (str, optional): ID of an existing changeset to read from
+
+    Returns:
+        A list of DataModelSecurityFilter objects or dictionaries
+        representing them.
+    """
+    data_model_id = data_model if isinstance(data_model, str) else data_model.id
+    security_filters = (
+        data_models.list_data_model_security_filters(
+            connection,
+            id=data_model_id,
+            changeset_id=changeset_id,
+            offset=offset,
+            limit=limit,
+        )
+        .json()
+        .get('securityFilters', [])
+    )
+    if limit:
+        security_filters = security_filters[:limit]
+    if to_dictionary:
+        return [unpack_information_dict(sf) for sf in security_filters]
+    return [
+        DataModelSecurityFilter._from_api_source(connection, data_model_id, sf)
+        for sf in security_filters
+    ]
+
+
+@class_version_handler('11.6.0100')
+class DataModelSecurityFilter(DataModelComponent):
+    """Python representation of a security filter of a Mosaic data model.
+
+    Security filter definitions are managed through the changeset-scoped
+    Modeling-Service endpoints, while member assignment uses the runtime
+    `/api/dataModels/{id}/securityFilters/{sfId}/members` endpoint. Member
+    assignment requires the security filter's creation changeset to be
+    committed first (this happens automatically, as every write api call
+    commits its own changeset).
+    """
+
+    _ACL_SUBTYPE = 'md_security_filter'
+    _GET_FUNC = staticmethod(data_models.get_data_model_security_filter)
+    _DELETE_FUNC = staticmethod(data_models.delete_data_model_security_filter)
+    _ID_KWARG = 'security_filter_id'
+
+    @classmethod
+    def create(
+        cls,
+        connection: Connection,
+        data_model: 'DataModel | str',
+        name: str,
+        qualification: dict,
+        top_level: list | None = None,
+        bottom_level: list | None = None,
+        description: str | None = None,
+        show_filter_tokens: bool | None = None,
+        show_expression_as: str | None = None,
+    ) -> 'DataModelSecurityFilter':
+        """Create a new security filter in a Mosaic data model.
+
+        Note:
+            The object subtype MUST be `md_security_filter` (it is set
+            automatically; plain `security_filter` is rejected). Two verified
+            qualification tree shapes:
+
+            - `predicate_form_qualification` - the form reference inside must
+              carry `subType: 'attribute_form_system'`
+            - `predicate_element_list` - with
+              `elements: [{'display': ..., 'elementId': ...}]` and
+              `function: 'in'`
+
+        Args:
+            connection (Connection): Strategy One connection object returned
+                by `connection.Connection()`
+            data_model (DataModel | str): data model object or its ID
+            name (str): name of the security filter
+            qualification (dict): filter definition written as an expression
+                tree over predicate nodes (`ms-Expression` schema)
+            top_level (list, optional): top level attributes of the filter
+            bottom_level (list, optional): bottom level attributes of the
+                filter
+            description (str, optional): description of the security filter
+            show_filter_tokens (bool, optional): whether to show filter
+                expressions as tokens in the response
+            show_expression_as (str, optional): specify how expressions are
+                presented in the response ('tree' or 'tokens')
+
+        Returns:
+            DataModelSecurityFilter object.
+        """
+        data_model_id = data_model if isinstance(data_model, str) else data_model.id
+        body = {
+            'name': name,
+            'description': description,
+            'subType': 'md_security_filter',
+            'qualification': qualification,
+            'topLevel': top_level or [],
+            'bottomLevel': bottom_level or [],
+        }
+        body = delete_none_values(body, recursion=False)
+        response = data_models.create_data_model_security_filter(
+            connection,
+            id=data_model_id,
+            body=body,
+            show_filter_tokens=show_filter_tokens,
+            show_expression_as=show_expression_as,
+        ).json()
+        if config.verbose:
+            logger.info(
+                f"Successfully created security filter named: '{name}' with "
+                f"ID: '{response.get('id')}' in data model '{data_model_id}'."
+            )
+        return cls._from_api_source(connection, data_model_id, response)
+
+    def alter(
+        self,
+        name: str | None = None,
+        description: str | None = None,
+        qualification: dict | None = None,
+        top_level: list | None = None,
+        bottom_level: list | None = None,
+    ) -> None:
+        """Alter the security filter.
+
+        Note:
+            The underlying endpoint is a PUT (full replace). This method
+            first fetches the current definition and merges the requested
+            changes into it before sending, so unspecified fields are
+            preserved.
+
+        Args:
+            name (str, optional): new name of the security filter
+            description (str, optional): new description
+            qualification (dict, optional): new filter definition
+            top_level (list, optional): new top level attributes
+            bottom_level (list, optional): new bottom level attributes
+        """
+        current = (
+            type(self)
+            ._GET_FUNC(
+                self.connection, id=self.data_model_id, security_filter_id=self.id
+            )
+            .json()
+        )
+        body = {key: val for key, val in current.items() if key != 'id'}
+        changes = {
+            'name': name,
+            'description': description,
+            'qualification': qualification,
+            'topLevel': top_level,
+            'bottomLevel': bottom_level,
+        }
+        body.update(delete_none_values(changes, recursion=False))
+        response = data_models.update_data_model_security_filter(
+            self.connection,
+            id=self.data_model_id,
+            security_filter_id=self.id,
+            body=body,
+        )
+        self._set_object_attributes(**unpack_information_dict(response.json()))
+        if config.verbose:
+            logger.info(
+                f"Successfully altered security filter with ID: '{self.id}' "
+                f"in data model '{self.data_model_id}'."
+            )
+
+    def list_members(
+        self,
+        offset: int | None = None,
+        limit: int | None = None,
+        to_dictionary: bool = True,
+    ) -> dict:
+        """List users and user groups the security filter is assigned to
+        (runtime endpoint).
+
+        Args:
+            offset (int, optional): starting point within the collection
+            limit (int, optional): limit the number of elements returned
+            to_dictionary (bool, optional): if True (default), members are
+                returned as plain dicts; if False, they are hydrated into
+                `User` / `UserGroup` objects
+
+        Returns:
+            Dictionary with keys `users`, `user_groups`, `total_users` and
+            `total_user_groups`. The totals are authoritative and may exceed
+            the number of returned members when paging.
+        """
+        data = data_models.get_security_filter_members(
+            self.connection,
+            id=self.data_model_id,
+            security_filter_id=self.id,
+            offset=offset,
+            limit=limit,
+        ).json()
+        members = data.get('users', []) + data.get('userGroups', [])
+        users = [m for m in members if m.get('subtype') != _USER_GROUP_SUBTYPE]
+        user_groups = [m for m in members if m.get('subtype') == _USER_GROUP_SUBTYPE]
+        if not to_dictionary:
+            from mstrio.users_and_groups import User, UserGroup
+
+            users = [
+                User.from_dict(source=user, connection=self.connection)
+                for user in users
+            ]
+            user_groups = [
+                UserGroup.from_dict(source=group, connection=self.connection)
+                for group in user_groups
+            ]
+        return {
+            'users': users,
+            'user_groups': user_groups,
+            'total_users': data.get('totalUsers'),
+            'total_user_groups': data.get('totalUserGroups'),
+        }
+
+    def _update_members(self, op: str, members: list['UserOrGroup']) -> bool:
+        """Send a member operation. `op` must be one of the one-word
+        camelCase verbs `addElements`, `removeElements` or `replaceElements`
+        (plain 'add' is rejected by the server) and the path must be exactly
+        `/Members`."""
+        from mstrio.users_and_groups import User, UserGroup
+
+        member_ids = [
+            member.id if isinstance(member, (User, UserGroup)) else member
+            for member in members
+        ]
+        body = {'operationList': [{'op': op, 'path': '/Members', 'value': member_ids}]}
+        response = data_models.update_security_filter_members(
+            self.connection,
+            id=self.data_model_id,
+            security_filter_id=self.id,
+            body=body,
+        )
+        if response.ok and config.verbose:
+            logger.info(
+                f"Successfully updated members of security filter with ID: "
+                f"'{self.id}' (operation: '{op}')."
+            )
+        return response.ok
+
+    def add_members(self, members: list['UserOrGroup']) -> bool:
+        """Assign users or user groups to the security filter.
+
+        Args:
+            members (list): list of `User` / `UserGroup` objects or their IDs
+
+        Returns:
+            True on success (the endpoint returns 204 with an empty body).
+        """
+        return self._update_members('addElements', members)
+
+    def remove_members(self, members: list['UserOrGroup']) -> bool:
+        """Unassign users or user groups from the security filter.
+
+        Args:
+            members (list): list of `User` / `UserGroup` objects or their IDs
+
+        Returns:
+            True on success (the endpoint returns 204 with an empty body).
+        """
+        return self._update_members('removeElements', members)
+
+    def replace_members(self, members: list['UserOrGroup']) -> bool:
+        """Replace the whole member list of the security filter.
+
+        Args:
+            members (list): list of `User` / `UserGroup` objects or their IDs
+
+        Returns:
+            True on success (the endpoint returns 204 with an empty body).
+        """
+        return self._update_members('replaceElements', members)

--- a/mstrio/modeling/data_model/data_model_table.py
+++ b/mstrio/modeling/data_model/data_model_table.py
@@ -1,0 +1,193 @@
+import logging
+from typing import TYPE_CHECKING
+
+from mstrio import config
+from mstrio.api import data_models
+from mstrio.connection import Connection
+from mstrio.modeling.data_model.data_model_component import DataModelComponent
+from mstrio.modeling.data_model.helpers import unpack_information_dict
+from mstrio.utils.helper import delete_none_values
+from mstrio.utils.version_helper import class_version_handler, method_version_handler
+
+if TYPE_CHECKING:
+    from mstrio.modeling.data_model.data_model import DataModel
+
+logger = logging.getLogger(__name__)
+
+
+@method_version_handler('11.6.0100')
+def list_data_model_tables(
+    connection: Connection,
+    data_model: 'DataModel | str',
+    to_dictionary: bool = False,
+    limit: int | None = None,
+    offset: int | None = None,
+    fields: str | None = None,
+    show_expression_as: str | None = None,
+    show_derived_columns: bool | None = None,
+    show_derived_forms: bool | None = None,
+    show_relationship_candidates: bool | None = None,
+    changeset_id: str | None = None,
+) -> list['DataModelTable'] | list[dict]:
+    """Get a list of tables of a Mosaic data model.
+
+    Args:
+        connection (Connection): Strategy One connection object returned
+            by `connection.Connection()`
+        data_model (DataModel | str): data model object or its ID
+        to_dictionary (bool, optional): if True, return tables as
+            a list of dicts
+        limit (int, optional): limit the number of elements returned
+        offset (int, optional): starting point within the collection
+        fields (str, optional): comma-separated top-level field whitelist
+        show_expression_as (str, optional): specify how expressions are
+            presented ('tree' or 'tokens')
+        show_derived_columns (bool, optional): whether to show derived columns
+        show_derived_forms (bool, optional): whether to show derived forms
+        show_relationship_candidates (bool, optional): whether to show
+            relationship candidates
+        changeset_id (str, optional): ID of an existing changeset to read from
+
+    Returns:
+        A list of DataModelTable objects or dictionaries representing them.
+    """
+    data_model_id = data_model if isinstance(data_model, str) else data_model.id
+    tables = (
+        data_models.list_data_model_tables(
+            connection,
+            id=data_model_id,
+            changeset_id=changeset_id,
+            offset=offset,
+            limit=limit,
+            fields=fields,
+            show_expression_as=show_expression_as,
+            show_derived_columns=show_derived_columns,
+            show_derived_forms=show_derived_forms,
+            show_relationship_candidates=show_relationship_candidates,
+        )
+        .json()
+        .get('tables', [])
+    )
+    if limit:
+        tables = tables[:limit]
+    if to_dictionary:
+        return [unpack_information_dict(table) for table in tables]
+    return [
+        DataModelTable._from_api_source(connection, data_model_id, table)
+        for table in tables
+    ]
+
+
+@class_version_handler('11.6.0100')
+class DataModelTable(DataModelComponent):
+    """Python representation of a logical table of a Mosaic data model."""
+
+    _ACL_SUBTYPE = 'logical_table'
+    _GET_FUNC = staticmethod(data_models.get_data_model_table)
+    _DELETE_FUNC = staticmethod(data_models.delete_data_model_table)
+    _ID_KWARG = 'table_id'
+
+    @classmethod
+    def create(
+        cls,
+        connection: Connection,
+        data_model: 'DataModel | str',
+        name: str,
+        physical_table: dict,
+        description: str | None = None,
+        definition: dict | None = None,
+        fields: str | None = None,
+        show_derived_columns: bool | None = None,
+        show_derived_forms: bool | None = None,
+    ) -> 'DataModelTable':
+        """Add a new logical table to a Mosaic data model.
+
+        Args:
+            connection (Connection): Strategy One connection object returned
+                by `connection.Connection()`
+            data_model (DataModel | str): data model object or its ID
+            name (str): name of the table
+            physical_table (dict): physical table definition. Three `type`
+                variants are supported:
+                - `warehouse_partition_table`: `{'type':
+                  'warehouse_partition_table', 'namespace': ..., 'tableName':
+                  ..., 'databaseInstance': {'objectId': ...}}`
+                - `pipeline`: table backed by a data-server pipeline
+                - `freeform_sql`: `{'type': 'freeform_sql', 'sqlStatement':
+                  ..., 'columns': [...]}`
+            description (str, optional): description of the table
+            definition (dict, optional): additional top-level body keys of the
+                `ms-DataModelTableAdd` schema, merged into the request body
+                (e.g. `primaryDataSource`)
+            fields (str, optional): comma-separated top-level field whitelist
+            show_derived_columns (bool, optional): whether to show derived
+                columns in the response
+            show_derived_forms (bool, optional): whether to show derived forms
+                in the response
+
+        Note:
+            Publish silently no-ops when physical-table columns carry
+            warehouse-catalog sentinel dataTypes (e.g. `variable_length_string`
+            with precision -1, or decimal with scale -MIN_INT). Replace such
+            sentinel values with real precisions/scales before creating the
+            table, otherwise `DataModel.publish` will report success without
+            loading any data.
+
+        Returns:
+            DataModelTable object.
+        """
+        data_model_id = data_model if isinstance(data_model, str) else data_model.id
+        body = {
+            'name': name,
+            'description': description,
+            'physicalTable': physical_table,
+            **(definition or {}),
+        }
+        body = delete_none_values(body, recursion=False)
+        response = data_models.create_data_model_table(
+            connection,
+            id=data_model_id,
+            body=body,
+            fields=fields,
+            show_derived_columns=show_derived_columns,
+            show_derived_forms=show_derived_forms,
+        ).json()
+        if config.verbose:
+            logger.info(
+                f"Successfully created table named: '{name}' with ID: '"
+                f"{response.get('id')}' in data model '{data_model_id}'."
+            )
+        return cls._from_api_source(connection, data_model_id, response)
+
+    def alter(
+        self,
+        name: str | None = None,
+        description: str | None = None,
+        physical_table: dict | None = None,
+        definition: dict | None = None,
+    ) -> None:
+        """Alter the table (partial update via PATCH).
+
+        Args:
+            name (str, optional): new name of the table
+            description (str, optional): new description of the table
+            physical_table (dict, optional): new physical table definition
+            definition (dict, optional): additional top-level body keys merged
+                into the request body
+        """
+        body = {
+            'name': name,
+            'description': description,
+            'physicalTable': physical_table,
+            **(definition or {}),
+        }
+        body = delete_none_values(body, recursion=False)
+        response = data_models.update_data_model_table(
+            self.connection, id=self.data_model_id, table_id=self.id, body=body
+        )
+        self._set_object_attributes(**unpack_information_dict(response.json()))
+        if config.verbose:
+            logger.info(
+                f"Successfully altered table with ID: '{self.id}' in data "
+                f"model '{self.data_model_id}'."
+            )

--- a/mstrio/modeling/data_model/helpers.py
+++ b/mstrio/modeling/data_model/helpers.py
@@ -1,0 +1,151 @@
+from dataclasses import dataclass, field
+from enum import auto
+
+from mstrio.utils.enum_helper import AutoName
+from mstrio.utils.helper import Dictable
+
+# The server's magic "Full Control" ACL rights mask. It is a single opaque
+# value and must NOT be decomposed from individual right flag names.
+_ACL_RIGHT_FULL_CONTROL = 255
+
+
+class DataServeMode(AutoName):
+    """Modes in which a Mosaic data model serves data."""
+
+    CONNECT_LIVE = auto()
+    IN_MEMORY = auto()
+    HYBRID = auto()
+    # Additional value present in the `ms-DataModel.dataServeMode` REST schema
+    OFF_MEMORY = auto()
+
+
+class RefreshPolicy(AutoName):
+    """Table refresh policies used when publishing a data model."""
+
+    ADD = auto()
+    REPLACE = auto()
+    DELETE = auto()
+    UPDATE = auto()
+    UPSERT = auto()
+    IGNORE = auto()
+    RESERVED = auto()
+
+
+@dataclass
+class TablePublishStatus(Dictable):
+    """Publish status of a single table of a Mosaic data model.
+
+    Attributes:
+        id (str): logical table ID
+        status (str): table load status; progresses `reserved` ->
+            `schema_comparison_completed` -> `loaded`, or `error` on failure
+        error_code (int, optional): error code when `status` is `error`
+        error_message (str, optional): error message when `status` is `error`
+    """
+
+    id: str | None = None
+    status: str | None = None
+    error_code: int | None = None
+    error_message: str | None = None
+
+
+@dataclass
+class DataModelPublishStatus(Dictable):
+    """Publish status of a Mosaic data model instance.
+
+    Attributes:
+        status (int): overall status; 0 = all tables loaded (success),
+            1 = queued/running, 5 = reserved, 6 = schema compared,
+            negative values are server errors (e.g. -2147212544 indicates a
+            tenant-side QueryEngine stall - do not retry in a loop)
+        tables (list[TablePublishStatus]): per-table publish statuses
+    """
+
+    _FROM_DICT_MAP = {'tables': [TablePublishStatus.from_dict]}
+
+    status: int | None = None
+    tables: list[TablePublishStatus] = field(default_factory=list)
+
+
+@dataclass
+class DataModelFolder(Dictable):
+    """Folder living inside a Mosaic data model (`ms-DataModelFolder`).
+
+    Attributes:
+        information (dict): object information block (objectId, name, ...)
+        contents (list): objects placed in the folder
+    """
+
+    information: dict | None = None
+    contents: list | None = None
+
+    @property
+    def id(self) -> str | None:
+        """ID of the folder taken from the `information` block."""
+        return (self.information or {}).get('object_id') or (
+            self.information or {}
+        ).get('objectId')
+
+    @property
+    def name(self) -> str | None:
+        """Name of the folder taken from the `information` block."""
+        return (self.information or {}).get('name')
+
+
+@dataclass
+class DataModelLink(Dictable):
+    """Link between data model objects (`ms-DataModelLink`).
+
+    Attributes:
+        id (str): link ID
+        targets (list): list of link units
+        source_object_id (str): ID of the source object
+        alias (str): link alias
+        linked_attribute (dict): the attribute which contains the source
+            attribute's forms and other target attributes' non-key single forms
+    """
+
+    id: str | None = None
+    targets: list | None = None
+    source_object_id: str | None = None
+    alias: str | None = None
+    linked_attribute: dict | None = None
+
+
+@dataclass
+class ExternalDataModel(Dictable):
+    """External data model reference (`ms-ExternalDataModel`).
+
+    Attributes:
+        id (str): external data model ID
+        base_data_model (dict): reference to the base data model
+        alias (str): alias of the external data model
+        objects (list): external data model units
+    """
+
+    id: str | None = None
+    base_data_model: dict | None = None
+    alias: str | None = None
+    objects: list | None = None
+
+
+def unpack_information_dict(source: dict) -> dict:
+    """Merge the `information` block of a Modeling-Service payload into the
+    top level of the dictionary.
+
+    Mirrors the response half of
+    `mstrio.utils.api_helpers.unpack_information`, for use on single elements
+    of collection responses.
+
+    Args:
+        source (dict): dictionary possibly containing an `information` block
+
+    Returns:
+        A copy of `source` with `information` merged to the top level and
+        `id` set from `information.objectId`.
+    """
+    result = source.copy()
+    if result.get('information'):
+        result.update(result.pop('information'))
+        result['id'] = result.pop('objectId', None)
+    return result

--- a/mstrio/modeling/schema/attribute/__init__.py
+++ b/mstrio/modeling/schema/attribute/__init__.py
@@ -1,6 +1,12 @@
 # flake8: noqa
 from .attribute_form import AttributeForm
 from .relationship import Relationship, RelationshipType
+from .smart_attribute import (
+    SmartAttribute,
+    list_smart_attribute_templates,
+    list_smart_attributes,
+    update_smart_attributes,
+)
 
 # isort: split
 

--- a/mstrio/modeling/schema/attribute/smart_attribute.py
+++ b/mstrio/modeling/schema/attribute/smart_attribute.py
@@ -1,0 +1,174 @@
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from mstrio import config
+from mstrio.api import smart_attributes as smart_attributes_api
+from mstrio.connection import Connection
+from mstrio.utils.helper import Dictable, get_objects_id
+from mstrio.utils.version_helper import method_version_handler
+
+if TYPE_CHECKING:
+    from mstrio.modeling.schema.attribute.attribute import Attribute
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SmartAttribute(Dictable):
+    """Object that describes a smart attribute derived from a base attribute.
+
+    Attributes:
+        object_id: ID of the smart attribute object
+        subtype: subtype of the smart attribute object
+        name: name of the smart attribute
+        definition: definition of the smart attribute
+    """
+
+    object_id: str | None = None
+    subtype: str | None = None
+    name: str | None = None
+    definition: dict | None = None
+
+
+def _get_attribute_id(attribute: 'Attribute | str') -> str:
+    # Import lazily to avoid a circular import: this module lives inside
+    # the `mstrio.modeling.schema.attribute` package which `attribute.py`
+    # is part of.
+    from mstrio.modeling.schema.attribute.attribute import Attribute
+
+    return get_objects_id(attribute, Attribute)
+
+
+def _unwrap_smart_attributes(
+    data: dict, root_key: str, to_dictionary: bool
+) -> list[SmartAttribute] | list[dict]:
+    elements = data.get(root_key) or []
+    if to_dictionary:
+        return elements
+    return [SmartAttribute.from_dict(element) for element in elements]
+
+
+@method_version_handler('11.6.0100')
+def list_smart_attributes(
+    connection: Connection,
+    attribute: 'Attribute | str',
+    to_dictionary: bool = False,
+    changeset_id: str | None = None,
+) -> list[SmartAttribute] | list[dict]:
+    """Get a list of references to all smart attributes derived from
+    the base attribute.
+
+    Args:
+        connection (Connection): Strategy One connection object returned
+            by `connection.Connection()`
+        attribute (Attribute, str): `Attribute` object or ID of the base
+            attribute
+        to_dictionary (bool, optional): If True returns a list of
+            dictionaries, otherwise returns a list of `SmartAttribute`
+            objects
+        changeset_id (str, optional): ID of a changeset. If provided, smart
+            attributes are read in the context of that changeset.
+
+    Returns:
+        A list of `SmartAttribute` objects or dictionaries representing
+        smart attributes.
+    """
+    attribute_id = _get_attribute_id(attribute)
+    response = smart_attributes_api.list_smart_attributes(
+        connection=connection,
+        attribute_id=attribute_id,
+        changeset_id=changeset_id,
+    )
+    return _unwrap_smart_attributes(response.json(), 'smartAttributes', to_dictionary)
+
+
+@method_version_handler('11.6.0100')
+def list_smart_attribute_templates(
+    connection: Connection,
+    attribute: 'Attribute | str',
+    to_dictionary: bool = False,
+    changeset_id: str | None = None,
+) -> list[SmartAttribute] | list[dict]:
+    """Get a list of smart attribute templates that can be created
+    for the base attribute.
+
+    Args:
+        connection (Connection): Strategy One connection object returned
+            by `connection.Connection()`
+        attribute (Attribute, str): `Attribute` object or ID of the base
+            attribute
+        to_dictionary (bool, optional): If True returns a list of
+            dictionaries, otherwise returns a list of `SmartAttribute`
+            objects
+        changeset_id (str, optional): ID of a changeset. If provided,
+            templates are read in the context of that changeset.
+
+    Returns:
+        A list of `SmartAttribute` objects or dictionaries representing
+        smart attribute templates.
+    """
+    attribute_id = _get_attribute_id(attribute)
+    response = smart_attributes_api.list_smart_attribute_templates(
+        connection=connection,
+        attribute_id=attribute_id,
+        changeset_id=changeset_id,
+    )
+    return _unwrap_smart_attributes(
+        response.json(), 'smartAttributesTemplates', to_dictionary
+    )
+
+
+@method_version_handler('11.6.0100')
+def update_smart_attributes(
+    connection: Connection,
+    attribute: 'Attribute | str',
+    smart_attributes: list[SmartAttribute | dict] | None = None,
+) -> list[SmartAttribute]:
+    """Reconcile the service-managed smart attributes for the base
+    attribute based on its key form.
+
+    Note:
+        This operation is a reconcile/merge, not a wholesale replacement.
+        If `smart_attributes` entries are provided, applicable entries are
+        merged into the service-managed set so fields such as `object_id`,
+        `name` and `hidden` are respected. Omitted existing applicable
+        entries are kept as-is; omitted missing applicable entries are
+        auto-created, and existing non-applicable smart attributes may be
+        removed. Passing `None` or an empty list lets the service
+        regenerate the set.
+
+    Args:
+        connection (Connection): Strategy One connection object returned
+            by `connection.Connection()`
+        attribute (Attribute, str): `Attribute` object or ID of the base
+            attribute
+        smart_attributes (list, optional): list of `SmartAttribute` objects
+            or dictionaries to merge into the service-managed set. If
+            `None` or empty, the service regenerates the smart attributes.
+
+    Returns:
+        A list of `SmartAttribute` objects representing the reconciled
+        smart attributes.
+    """
+    attribute_id = _get_attribute_id(attribute)
+    body = {}
+    if smart_attributes:
+        body['smartAttributes'] = [
+            item.to_dict() if isinstance(item, SmartAttribute) else item
+            for item in smart_attributes
+        ]
+    response = smart_attributes_api.update_smart_attributes(
+        connection=connection,
+        attribute_id=attribute_id,
+        body=body,
+    )
+    result = _unwrap_smart_attributes(
+        response.json(), 'smartAttributes', to_dictionary=False
+    )
+    if config.verbose:
+        logger.info(
+            "Successfully reconciled smart attributes for attribute "
+            f"with ID: '{attribute_id}'."
+        )
+    return result

--- a/mstrio/project_objects/__init__.py
+++ b/mstrio/project_objects/__init__.py
@@ -23,6 +23,7 @@ from .incremental_refresh_report import (
 from .library import Library
 from .palette import Palette, list_palettes
 from .report import Report, list_reports
+from .workspace import Pipeline, PipelineTable, Workspace
 
 import warnings as _w
 with _w.catch_warnings():  # FYI: simpler setup was added in 3.11

--- a/mstrio/project_objects/workspace.py
+++ b/mstrio/project_objects/workspace.py
@@ -1,0 +1,642 @@
+"""Mosaic data-server workspaces, pipelines and pipeline tables.
+
+Note:
+    The REST API surface has no collection-GET endpoint for workspaces,
+    pipelines or tables, so no `list_*` functions are provided. Obtain
+    workspace and pipeline IDs from Studio or from data-model pipeline
+    table definitions; nested pipeline definitions are returned inside
+    the workspace GET payload.
+"""
+
+import logging
+
+from mstrio import config
+from mstrio.api import workspaces
+from mstrio.connection import Connection
+from mstrio.utils.entity import EntityBase
+from mstrio.utils.helper import delete_none_values
+from mstrio.utils.version_helper import class_version_handler
+
+logger = logging.getLogger(__name__)
+
+
+@class_version_handler('11.6.0100')
+class Workspace(EntityBase):
+    """A Mosaic data-server workspace.
+
+    There is no collection-GET endpoint for workspaces, so listing them is
+    not supported. Obtain workspace IDs from Studio or from data-model
+    pipeline table definitions.
+
+    Attributes:
+        id (str): ID of the workspace
+        project_id (str): ID of the project the workspace belongs to; if
+            None, the project selected on the connection applies
+        date_created (str): creation date/time of the workspace
+        date_modified (str): last modification date/time of the workspace
+        dataset_serve_mode (str): serve mode of the workspace's dataset,
+            one of: 'in_memory', 'connect_live', 'off_memory'
+        sampling (dict): sampling settings, e.g.
+            `{'type': 'first' | 'random', 'rowCount': 1000}`
+        dss_host (str): DSS host
+        dss_port (int): DSS port
+        pipelines (list[Pipeline]): pipelines defined in the workspace
+    """
+
+    _API_GETTERS = {
+        (
+            'id',
+            'date_created',
+            'date_modified',
+            'dataset_serve_mode',
+            'sampling',
+            'dss_host',
+            'dss_port',
+            'pipelines',
+        ): workspaces.get_workspace
+    }
+
+    def __init__(
+        self, connection: Connection, id: str, project_id: str | None = None
+    ) -> None:
+        """Initialize the Workspace object and fetch it from the server.
+
+        Args:
+            connection (Connection): Strategy One connection object returned
+                by `connection.Connection()`
+            id (str): ID of the workspace
+            project_id (str, optional): ID of a project; if omitted, the
+                project selected on the connection is used
+        """
+        super().__init__(connection=connection, object_id=id, project_id=project_id)
+
+    def _init_variables(self, default_value=None, **kwargs) -> None:
+        super()._init_variables(default_value=default_value, **kwargs)
+        self.project_id = kwargs.get('project_id')
+        self.date_created = kwargs.get('date_created', default_value)
+        self.date_modified = kwargs.get('date_modified', default_value)
+        self.dataset_serve_mode = kwargs.get('dataset_serve_mode', default_value)
+        self.sampling = kwargs.get('sampling', default_value)
+        self.dss_host = kwargs.get('dss_host', default_value)
+        self.dss_port = kwargs.get('dss_port', default_value)
+        self._pipelines = kwargs.get('pipelines', default_value)
+
+    @classmethod
+    def create(
+        cls,
+        connection: Connection,
+        dataset_serve_mode: str | None = None,
+        sampling: dict | None = None,
+        pipelines: list[dict] | None = None,
+        project_id: str | None = None,
+    ) -> 'Workspace':
+        """Create a new workspace on the data server.
+
+        Args:
+            connection (Connection): Strategy One connection object returned
+                by `connection.Connection()`
+            dataset_serve_mode (str, optional): serve mode of the workspace's
+                dataset, one of: 'in_memory', 'connect_live', 'off_memory'
+            sampling (dict, optional): sampling settings, e.g.
+                `{'type': 'first' | 'random', 'rowCount': 1000}`
+            pipelines (list[dict], optional): pipeline definitions
+                (`ms-Pipeline`) to create the workspace with
+            project_id (str, optional): ID of a project; if omitted, the
+                project selected on the connection is used
+
+        Returns:
+            Workspace object with the newly created workspace's definition.
+        """
+        body = delete_none_values(
+            {
+                'datasetServeMode': dataset_serve_mode,
+                'sampling': sampling,
+                'pipelines': pipelines,
+            },
+            recursion=False,
+        )
+        response = workspaces.create_workspace(
+            connection, body=body, project_id=project_id
+        )
+        workspace = cls.from_dict(
+            source={**response.json(), 'project_id': project_id},
+            connection=connection,
+        )
+        if config.verbose:
+            logger.info(f"Successfully created workspace with ID: '{workspace.id}'.")
+        return workspace
+
+    def alter(
+        self,
+        dataset_serve_mode: str | None = None,
+        sampling: dict | None = None,
+    ) -> None:
+        """Alter the workspace's properties.
+
+        Args:
+            dataset_serve_mode (str, optional): serve mode of the workspace's
+                dataset, one of: 'in_memory', 'connect_live', 'off_memory'
+            sampling (dict, optional): sampling settings, e.g.
+                `{'type': 'first' | 'random', 'rowCount': 1000}`
+
+        Returns:
+            None
+        """
+        body = delete_none_values(
+            {'datasetServeMode': dataset_serve_mode, 'sampling': sampling},
+            recursion=False,
+        )
+        response = workspaces.update_workspace(
+            self.connection, self.id, body=body, project_id=self.project_id
+        )
+        self._set_object_attributes(**response.json())
+        if config.verbose:
+            logger.info(f"Successfully updated workspace with ID: '{self.id}'.")
+
+    def delete(self, force: bool = False) -> bool:
+        """Delete the workspace.
+
+        Args:
+            force (bool, optional): if True, no additional prompt will be
+                shown before deleting the workspace, defaults to False
+
+        Returns:
+            True on success. False otherwise.
+        """
+        if not force:
+            user_input = input(
+                f"Are you sure you want to delete Workspace with ID: "
+                f"'{self.id}'? [Y/N]: "
+            )
+            if user_input != 'Y':
+                return False
+        response = workspaces.delete_workspace(
+            self.connection, self.id, project_id=self.project_id
+        )
+        if response.ok and config.verbose:
+            logger.info(f"Successfully deleted Workspace with ID: '{self.id}'.")
+        return response.ok
+
+    @property
+    def pipelines(self) -> list['Pipeline']:
+        """Pipelines defined in the workspace, built from the fetched
+        workspace definition."""
+        if self._pipelines is None:
+            self.fetch()
+        return [
+            Pipeline.from_dict(
+                source={
+                    **pipeline,
+                    'workspace_id': self.id,
+                    'project_id': self.project_id,
+                },
+                connection=self.connection,
+            )
+            for pipeline in self._pipelines or []
+        ]
+
+    def create_pipeline(
+        self,
+        name: str | None = None,
+        root_table: dict | None = None,
+        sql: str | None = None,
+        body: dict | None = None,
+    ) -> 'Pipeline':
+        """Create a new pipeline in the workspace.
+
+        Args:
+            name (str, optional): name of the new pipeline (required by the
+                server when creating a pipeline with a definition)
+            root_table (dict, optional): root table of the pipeline's
+                hierarchical table structure (`ms-dataServerRootTable`;
+                required by the server when creating a pipeline with
+                a definition)
+            sql (str, optional): SQL of the pipeline
+            body (dict, optional): full JSON-formatted `ms-Pipeline`
+                definition; takes precedence over the other arguments.
+                If no arguments are provided, an empty pipeline is created.
+
+        Returns:
+            Pipeline object with the newly created pipeline's definition.
+        """
+        if body is None:
+            body = delete_none_values(
+                {'name': name, 'rootTable': root_table, 'sql': sql},
+                recursion=False,
+            )
+        response = workspaces.create_pipeline(
+            self.connection, self.id, body=body, project_id=self.project_id
+        )
+        pipeline = Pipeline.from_dict(
+            source={
+                **response.json(),
+                'workspace_id': self.id,
+                'project_id': self.project_id,
+            },
+            connection=self.connection,
+        )
+        if config.verbose:
+            logger.info(
+                f"Successfully created pipeline with ID: '{pipeline.id}' "
+                f"in workspace with ID: '{self.id}'."
+            )
+        return pipeline
+
+    def get_pipeline(self, pipeline_id: str) -> 'Pipeline':
+        """Get a single pipeline of the workspace by its ID.
+
+        Args:
+            pipeline_id (str): ID of the pipeline
+
+        Returns:
+            Pipeline object fetched from the server.
+        """
+        return Pipeline(
+            connection=self.connection,
+            workspace_id=self.id,
+            id=pipeline_id,
+            project_id=self.project_id,
+        )
+
+
+@class_version_handler('11.6.0100')
+class Pipeline(EntityBase):
+    """A data processing pipeline within a Mosaic data-server workspace.
+
+    There is no collection-GET endpoint for pipelines, so listing them
+    directly is not supported. Use `Workspace.pipelines`, which is built
+    from the workspace GET payload, or obtain pipeline IDs from Studio or
+    from data-model pipeline table definitions.
+
+    Attributes:
+        id (str): ID of the pipeline
+        workspace_id (str): ID of the workspace the pipeline belongs to
+        project_id (str): ID of the project the pipeline belongs to; if
+            None, the project selected on the connection applies
+        name (str): name of the pipeline
+        sql (str): SQL of the pipeline
+        root_table (dict): root table of the pipeline's hierarchical table
+            structure (`ms-dataServerRootTable`)
+    """
+
+    _API_GETTERS = {('id', 'name', 'sql', 'root_table'): workspaces.get_pipeline}
+
+    def __init__(
+        self,
+        connection: Connection,
+        workspace_id: str,
+        id: str,
+        project_id: str | None = None,
+    ) -> None:
+        """Initialize the Pipeline object and fetch it from the server.
+
+        Args:
+            connection (Connection): Strategy One connection object returned
+                by `connection.Connection()`
+            workspace_id (str): ID of the workspace the pipeline belongs to
+            id (str): ID of the pipeline
+            project_id (str, optional): ID of a project; if omitted, the
+                project selected on the connection is used
+        """
+        super().__init__(
+            connection=connection,
+            object_id=id,
+            workspace_id=workspace_id,
+            project_id=project_id,
+        )
+
+    def _init_variables(self, default_value=None, **kwargs) -> None:
+        super()._init_variables(default_value=default_value, **kwargs)
+        self.workspace_id = kwargs.get('workspace_id')
+        self.project_id = kwargs.get('project_id')
+        self.sql = kwargs.get('sql', default_value)
+        self.root_table = kwargs.get('root_table', default_value)
+
+    def fetch(self, attr: str | None = None) -> None:
+        """Fetch the latest pipeline definition from the server.
+
+        Args:
+            attr (str, optional): ignored; present for compatibility with
+                the base class. The whole definition is always fetched.
+
+        Returns:
+            None
+        """
+        response = workspaces.get_pipeline(
+            self.connection,
+            workspace_id=self.workspace_id,
+            pipeline_id=self.id,
+            project_id=self.project_id,
+        )
+        self._set_object_attributes(**response.json())
+        for key in self._API_GETTERS:
+            self._add_to_fetched(key)
+
+    def alter(
+        self,
+        name: str | None = None,
+        root_table: dict | None = None,
+        sql: str | None = None,
+        body: dict | None = None,
+    ) -> None:
+        """Alter the pipeline's definition.
+
+        Args:
+            name (str, optional): new name of the pipeline
+            root_table (dict, optional): new root table of the pipeline's
+                hierarchical table structure (`ms-dataServerRootTable`)
+            sql (str, optional): new SQL of the pipeline
+            body (dict, optional): full JSON-formatted `ms-Pipeline`
+                definition update; takes precedence over the other arguments
+
+        Returns:
+            None
+        """
+        if body is None:
+            body = delete_none_values(
+                {'name': name, 'rootTable': root_table, 'sql': sql},
+                recursion=False,
+            )
+        response = workspaces.update_pipeline(
+            self.connection,
+            self.workspace_id,
+            self.id,
+            body=body,
+            project_id=self.project_id,
+        )
+        self._set_object_attributes(**response.json())
+        if config.verbose:
+            logger.info(f"Successfully updated pipeline with ID: '{self.id}'.")
+
+    def delete(self, force: bool = False) -> bool:
+        """Delete the pipeline.
+
+        Args:
+            force (bool, optional): if True, no additional prompt will be
+                shown before deleting the pipeline, defaults to False
+
+        Returns:
+            True on success. False otherwise.
+        """
+        if not force:
+            user_input = input(
+                f"Are you sure you want to delete Pipeline with ID: "
+                f"'{self.id}'? [Y/N]: "
+            )
+            if user_input != 'Y':
+                return False
+        response = workspaces.delete_pipeline(
+            self.connection,
+            self.workspace_id,
+            self.id,
+            project_id=self.project_id,
+        )
+        if response.ok and config.verbose:
+            logger.info(f"Successfully deleted Pipeline with ID: '{self.id}'.")
+        return response.ok
+
+    def refresh(self) -> None:
+        """Refresh the pipeline to update its data and structure.
+
+        Returns:
+            None
+        """
+        workspaces.refresh_pipeline(
+            self.connection,
+            self.workspace_id,
+            self.id,
+            project_id=self.project_id,
+        )
+        if config.verbose:
+            logger.info(f"Successfully refreshed pipeline with ID: '{self.id}'.")
+
+    def create_table(self, body: dict | None = None) -> 'PipelineTable':
+        """Create a new table in the pipeline.
+
+        Args:
+            body (dict): JSON-formatted definition of the new table. The
+                server requires a typed table body:
+                `ms-dataServerSourceTable` (`'type': 'source'`, with
+                `columns`, `importSource`, `filter`, `sampling`) or
+                `ms-dataServerWrangleTable` (`'type': 'wrangle'`, with
+                `operations`, `columns`, `children`). An empty body `{}`
+                fails with `8004d102 InvalidTypeIdException`
+                (field-verified).
+
+        Returns:
+            PipelineTable object with the newly created table's definition.
+        """
+        response = workspaces.create_pipeline_table(
+            self.connection,
+            self.workspace_id,
+            self.id,
+            body=body,
+            project_id=self.project_id,
+        )
+        table = PipelineTable.from_dict(
+            source={
+                **response.json(),
+                'workspace_id': self.workspace_id,
+                'pipeline_id': self.id,
+                'project_id': self.project_id,
+            },
+            connection=self.connection,
+        )
+        if config.verbose:
+            logger.info(
+                f"Successfully created table with ID: '{table.id}' "
+                f"in pipeline with ID: '{self.id}'."
+            )
+        return table
+
+    def get_table(
+        self,
+        table_id: str,
+        show_preview_data: bool = False,
+        show_raw_data: bool = False,
+    ) -> 'PipelineTable':
+        """Get a single table of the pipeline by its ID.
+
+        Args:
+            table_id (str): ID of the table
+            show_preview_data (bool, optional): whether to include preview
+                data in the response, defaults to False
+            show_raw_data (bool, optional): whether to include raw data in
+                the response, defaults to False
+
+        Returns:
+            PipelineTable object fetched from the server.
+        """
+        response = workspaces.get_pipeline_table(
+            self.connection,
+            self.workspace_id,
+            self.id,
+            table_id,
+            project_id=self.project_id,
+            show_preview_data=show_preview_data,
+            show_raw_data=show_raw_data,
+        )
+        return PipelineTable.from_dict(
+            source={
+                **response.json(),
+                'workspace_id': self.workspace_id,
+                'pipeline_id': self.id,
+                'project_id': self.project_id,
+            },
+            connection=self.connection,
+        )
+
+
+@class_version_handler('11.6.0100')
+class PipelineTable(EntityBase):
+    """A table within a Mosaic data-server pipeline.
+
+    A pipeline table is either a source table (`ms-dataServerSourceTable`,
+    `table_type` 'source', with `columns`, `original_schema`,
+    `import_source`, `filter`, `sampling`, `preview_data`) or a wrangle
+    table (`ms-dataServerWrangleTable`, `table_type` 'wrangle', with
+    `operations`, `columns`, `children`, `preview_data`). Fetched fields
+    are stored generically as object attributes.
+
+    There is no collection-GET endpoint for pipeline tables, so listing
+    them directly is not supported. Obtain table IDs from Studio or from
+    data-model pipeline table definitions.
+
+    Attributes:
+        id (str): ID of the table
+        workspace_id (str): ID of the workspace the table belongs to
+        pipeline_id (str): ID of the pipeline the table belongs to
+        project_id (str): ID of the project the table belongs to; if None,
+            the project selected on the connection applies
+        table_type (str): type of the table: 'source' or 'wrangle'
+            (REST field `type`)
+    """
+
+    _REST_ATTR_MAP = {'type': 'table_type'}
+
+    def __init__(
+        self,
+        connection: Connection,
+        workspace_id: str,
+        pipeline_id: str,
+        id: str,
+        project_id: str | None = None,
+    ) -> None:
+        """Initialize the PipelineTable object and fetch it from the server.
+
+        Args:
+            connection (Connection): Strategy One connection object returned
+                by `connection.Connection()`
+            workspace_id (str): ID of the workspace the table belongs to
+            pipeline_id (str): ID of the pipeline the table belongs to
+            id (str): ID of the table
+            project_id (str, optional): ID of a project; if omitted, the
+                project selected on the connection is used
+        """
+        super().__init__(
+            connection=connection,
+            object_id=id,
+            workspace_id=workspace_id,
+            pipeline_id=pipeline_id,
+            project_id=project_id,
+        )
+        if config.fetch_on_init:
+            self.fetch()
+
+    def _init_variables(self, default_value=None, **kwargs) -> None:
+        kwargs = self._rest_to_python(kwargs)
+        super()._init_variables(default_value=default_value, **kwargs)
+        self.workspace_id = kwargs.get('workspace_id')
+        self.pipeline_id = kwargs.get('pipeline_id')
+        self.project_id = kwargs.get('project_id')
+        self.table_type = kwargs.get('table_type', default_value)
+        handled = {
+            'connection',
+            'id',
+            'name',
+            'table_type',
+            'workspace_id',
+            'pipeline_id',
+            'project_id',
+        }
+        for key, value in kwargs.items():
+            if key not in handled and not key.startswith('_'):
+                setattr(self, key, value)
+
+    def fetch(
+        self, show_preview_data: bool = False, show_raw_data: bool = False
+    ) -> None:
+        """Fetch the latest table definition from the server.
+
+        Args:
+            show_preview_data (bool, optional): whether to include preview
+                data in the response, defaults to False
+            show_raw_data (bool, optional): whether to include raw data in
+                the response, defaults to False
+
+        Returns:
+            None
+        """
+        response = workspaces.get_pipeline_table(
+            self.connection,
+            workspace_id=self.workspace_id,
+            pipeline_id=self.pipeline_id,
+            table_id=self.id,
+            project_id=self.project_id,
+            show_preview_data=show_preview_data,
+            show_raw_data=show_raw_data,
+        )
+        self._set_object_attributes(**response.json())
+        self._add_to_fetched('id')
+
+    def alter(self, body: dict) -> None:
+        """Alter the table's definition.
+
+        Args:
+            body (dict): JSON-formatted table definition update; shape
+                depends on the table type: `ms-dataServerSourceTable`
+                (`'type': 'source'`) or `ms-dataServerWrangleTable`
+                (`'type': 'wrangle'`)
+
+        Returns:
+            None
+        """
+        response = workspaces.update_pipeline_table(
+            self.connection,
+            self.workspace_id,
+            self.pipeline_id,
+            self.id,
+            body=body,
+            project_id=self.project_id,
+        )
+        self._set_object_attributes(**response.json())
+        if config.verbose:
+            logger.info(f"Successfully updated table with ID: '{self.id}'.")
+
+    def delete(self, force: bool = False) -> bool:
+        """Delete the table.
+
+        Args:
+            force (bool, optional): if True, no additional prompt will be
+                shown before deleting the table, defaults to False
+
+        Returns:
+            True on success. False otherwise.
+        """
+        if not force:
+            user_input = input(
+                f"Are you sure you want to delete PipelineTable with ID: "
+                f"'{self.id}'? [Y/N]: "
+            )
+            if user_input != 'Y':
+                return False
+        response = workspaces.delete_pipeline_table(
+            self.connection,
+            self.workspace_id,
+            self.pipeline_id,
+            self.id,
+            project_id=self.project_id,
+        )
+        if response.ok and config.verbose:
+            logger.info(f"Successfully deleted PipelineTable with ID: '{self.id}'.")
+        return response.ok

--- a/mstrio/server/__init__.py
+++ b/mstrio/server/__init__.py
@@ -37,6 +37,14 @@ from .license import (
     UserLicense,
 )
 from .lock import LockStatus, LockType
+from .mosaic import (
+    MosaicSettingsStatus,
+    MosaicSsoSettings,
+    commit_mosaic_settings,
+    get_mosaic_settings,
+    stage_mosaic_settings,
+    upload_mosaic_keytab,
+)
 from .node import Node
 from .project import (
     AdminObjectRule,

--- a/mstrio/server/mosaic.py
+++ b/mstrio/server/mosaic.py
@@ -1,0 +1,167 @@
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from mstrio import config
+from mstrio.api import mosaic as mosaic_api
+from mstrio.connection import Connection
+from mstrio.utils.helper import Dictable
+from mstrio.utils.version_helper import method_version_handler
+
+logger = logging.getLogger(__name__)
+
+
+class MosaicSettingsStatus(Enum):
+    """Status of the Mosaic SSO configuration.
+
+    `IN_PROGRESS` - settings are fetched from the sidecar (draft) file only.
+    `COMMITTED` - settings are fetched from the main config files only.
+    """
+
+    IN_PROGRESS = 'IN_PROGRESS'
+    COMMITTED = 'COMMITTED'
+
+
+@dataclass
+class MosaicSsoSettings(Dictable):
+    """Mosaic SSO settings of an environment.
+
+    Attributes:
+        krb5_realm (str, optional): Kerberos realm (uppercase FQDN),
+            e.g. CORP.MICROSTRATEGY.COM
+        mosaic_host (str, optional): Mosaic host used in SPN/keytab principal
+            (HTTP/<host>), e.g. demo.microstrategy.com
+        keytab_file_name (str, optional): keytab file name (without any path).
+            Written into config.properties as etc/<fileName>,
+            e.g. mci-jpd9h-dev-http.keytab
+        upn_domains (list[str], optional): all UPN domains. The first entry is
+            used as email suffix in user-mapping.json.
+        domain (str, optional): domain value used by UI and persisted for
+            round-trip. Not directly patched into config files.
+        mosaic_host_aliases (list[str], optional): Mosaic host aliases used by
+            UI and persisted for round-trip. Not patched into
+            config.properties.
+        mosaic_svc (str, optional): Mosaic service account value used by UI
+            and persisted for round-trip. Not directly patched into config
+            files.
+        status (MosaicSettingsStatus, optional): status of the configuration.
+            Read-only, server-populated. Stripped from request bodies when
+            staging or committing settings.
+    """
+
+    _FROM_DICT_MAP = {
+        'status': MosaicSettingsStatus,
+    }
+
+    krb5_realm: str | None = None
+    mosaic_host: str | None = None
+    keytab_file_name: str | None = None
+    upn_domains: list[str] | None = None
+    domain: str | None = None
+    mosaic_host_aliases: list[str] | None = None
+    mosaic_svc: str | None = None
+    status: MosaicSettingsStatus | str | None = None
+
+
+def _prepare_settings_body(settings: MosaicSsoSettings | dict) -> dict:
+    """Convert settings to a camelCase request body, stripping the read-only
+    `status` field."""
+    body = settings.to_dict() if isinstance(settings, Dictable) else dict(settings)
+    body.pop('status', None)
+    return body
+
+
+@method_version_handler('11.6.0100')
+def get_mosaic_settings(connection: Connection) -> MosaicSsoSettings:
+    """Get Mosaic SSO settings stored as files under universal semantic
+    service.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+
+    Returns:
+        MosaicSsoSettings object with the current Mosaic settings.
+    """
+    response = mosaic_api.get_mosaic_settings(connection)
+    return MosaicSsoSettings.from_dict(response.json())
+
+
+@method_version_handler('11.6.0100')
+def stage_mosaic_settings(
+    connection: Connection, settings: MosaicSsoSettings | dict
+) -> None:
+    """Save draft Mosaic SSO settings to a sidecar file without modifying
+    production config files. This allows saving work-in-progress
+    configuration.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        settings (MosaicSsoSettings, dict): Mosaic settings to stage. The
+            read-only `status` field is stripped before sending.
+
+    Returns:
+        None
+    """
+    mosaic_api.stage_mosaic_settings(connection, body=_prepare_settings_body(settings))
+    if config.verbose:
+        logger.info('Draft Mosaic settings have been staged.')
+
+
+@method_version_handler('11.6.0100')
+def commit_mosaic_settings(
+    connection: Connection, settings: MosaicSsoSettings | dict
+) -> None:
+    """Commit Mosaic SSO settings to production config files.
+
+    The server will update config.properties, krb5.conf and user-mapping.json
+    under universal semantic service. Requires existing baseline files. Also
+    enables JWT authentication mode.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        settings (MosaicSsoSettings, dict): Mosaic settings to commit. The
+            read-only `status` field is stripped before sending.
+
+    Returns:
+        None
+    """
+    mosaic_api.commit_mosaic_settings(connection, body=_prepare_settings_body(settings))
+    if config.verbose:
+        logger.info('Mosaic settings have been committed.')
+
+
+@method_version_handler('11.6.0100')
+def upload_mosaic_keytab(
+    connection: Connection,
+    file: str | Path | bytes,
+    file_name: str | None = None,
+) -> None:
+    """Upload a Mosaic keytab file to the local shared folder so other
+    services can access it.
+
+    Args:
+        connection (Connection): Strategy One connection object returned by
+            `connection.Connection()`
+        file (str, Path, bytes): path to the keytab file or its binary
+            content
+        file_name (str, optional): original file name of the keytab file
+            (used by the server for validation). Defaults to the base name
+            of `file` when a path is provided. Required when `file` is
+            passed as bytes.
+
+    Returns:
+        None
+    """
+    if isinstance(file, (str, Path)):
+        path = Path(file)
+        file_name = file_name or path.name
+        file = path.read_bytes()
+    elif file_name is None:
+        raise ValueError("'file_name' must be provided when 'file' is passed as bytes.")
+    mosaic_api.upload_mosaic_keytab(connection, file=file, file_name=file_name)
+    if config.verbose:
+        logger.info(f"Mosaic keytab file '{file_name}' has been uploaded.")


### PR DESCRIPTION
## Summary

Adds full SDK coverage for the Mosaic (semantic layer) REST API surface — **90 operations** currently unavailable in mstrio-py:

| Module | Coverage |
|---|---|
| `mstrio/api/data_models.py` | 64 wrappers for `/api/model/dataModels/*` + `/api/dataModels/*`: model lifecycle, tables, attributes, metrics, fact metrics, folders, links, external data models (data mesh), security filters, object ACLs/translations, YAML export/restore, publish + status polling |
| `mstrio/api/workspaces.py` | 13 wrappers for `/api/dataServer/workspaces/*`: workspaces, pipelines, pipeline tables |
| `mstrio/api/smart_attributes.py` | 6 wrappers for smart attributes (standalone + data-model-scoped) |
| `mstrio/api/mosaic.py` | 4 wrappers for Mosaic SSO admin settings (keytab upload, stage/commit settings) |

High-level classes follow the established Entity/mixin conventions and are version-gated at `11.6.0100`:

- `DataModel` + `DataModelTable` / `DataModelAttribute` / `DataModelMetric` / `DataModelFactMetric` / `DataModelSecurityFilter` in `mstrio.modeling.data_model`, with `list_data_models` and per-component `list_*` functions
- `Workspace` / `Pipeline` / `PipelineTable` in `mstrio.project_objects`
- `SmartAttribute` in `mstrio.modeling.schema.attribute`
- `MosaicSsoSettings` + module functions in `mstrio.server`
- A `code_snippets/` example per module; README and NEWS updated

## Design notes

- **Changesets**: modeling writes default to self-managed changesets (open → commit → delete per call, matching `mstrio.api.attributes`), and additionally accept a caller-owned `changeset_id`. This is necessary because the server enforces a minimum committable model: at least one table per model (`8004e46f`), at least one attribute or metric per table (`8004e42f`), and `displays` on every attribute (`8004cf06`). `DataModel.create(tables=..., attributes=...)` builds that minimum shape in a single changeset and resolves by-name logical-table references in attribute bodies, so callers are not exposed to the create-order id chicken-and-egg.
- **`DataModel.publish()`** wraps the full three-step runtime flow (create instance → publish with per-table refresh policies → poll `publishStatus`), since the publish POST returns 204 fire-and-forget.
- **Runtime endpoints** (`/api/dataModels/*`, `/api/dataServer/*`) always send `X-MSTR-ProjectID` (defaulted from the connection) — several reject its absence with `ERR006` even when a project is selected on the session.
- `export_data_model` returns `application/yaml` and is handled without the JSON `ErrorHandler`; `restore_data_model` and `upload_mosaic_keytab` use the multipart idiom from `mstrio.api.migration`.

## Testing

- Endpoint conformance against the public OpenAPI specification in both directions per module (every documented operation has exactly one wrapper; no undocumented endpoints).
- `black` / `isort` / `flake8` clean with the repo configuration; `import mstrio` and `compileall` clean on Python 3.12.
- Live-validated against a Strategy One 11.6.0500 cloud environment: all read paths on existing Mosaic models, and the full create → alter → save-as → YAML export → instance/publish-status → delete lifecycle on scratch objects (changeset rollback verified to leave no orphan metadata on failed commits).

A companion GitHub Issue will reference this PR per the contribution guidelines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)